### PR TITLE
use the new container infrastructure on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ rvm:
   - 2.2
 
 cache: bundler
+
+sudo: false


### PR DESCRIPTION
caching is only available on the new EC2 based workers for open source