### PR TITLE
Configure Travis build notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,8 @@ rvm:
 cache: bundler
 
 sudo: false
+
+notifications:
+  email:
+    on_success: never
+    on_failure: change


### PR DESCRIPTION
The default settings for open-source projects are a bit chatty for my tastes. This scopes them down to a more reasonable level.

@alex-stone @kruppel 