### PR TITLE
Pass periods directly into calculations

### DIFF
--- a/lib/biz/calculation/duration_within.rb
+++ b/lib/biz/calculation/duration_within.rb
@@ -2,9 +2,9 @@ module Biz
   module Calculation
     class DurationWithin < SimpleDelegator
 
-      def initialize(schedule, calculation_period)
+      def initialize(periods, calculation_period)
         super(
-          schedule.periods.after(calculation_period.start_time)
+          periods.after(calculation_period.start_time)
             .timeline.forward
             .until(calculation_period.end_time)
             .map(&:duration)

--- a/lib/biz/calculation/for_duration.rb
+++ b/lib/biz/calculation/for_duration.rb
@@ -2,27 +2,27 @@ module Biz
   module Calculation
     class ForDuration
 
-      attr_reader :schedule,
+      attr_reader :periods,
                   :duration
 
-      def initialize(schedule, duration)
+      def initialize(periods, duration)
         unless duration.positive?
           fail ArgumentError, 'Duration adjustment must be positive.'
         end
 
-        @schedule = schedule
+        @periods  = periods
         @duration = duration
       end
 
       def before(time)
-        schedule.periods.before(time)
+        periods.before(time)
           .timeline.backward
           .for(duration).to_a
           .last.start_time
       end
 
       def after(time)
-        schedule.periods.after(time)
+        periods.after(time)
           .timeline.forward
           .for(duration).to_a
           .last.end_time

--- a/lib/biz/schedule.rb
+++ b/lib/biz/schedule.rb
@@ -18,11 +18,17 @@ module Biz
     end
 
     def time(scalar, unit)
-      Calculation::ForDuration.new(self, Duration.with_unit(scalar, unit))
+      Calculation::ForDuration.new(
+        periods,
+        Duration.with_unit(scalar, unit)
+      )
     end
 
     def within(origin, terminus)
-      Calculation::DurationWithin.new(self, TimeSegment.new(origin, terminus))
+      Calculation::DurationWithin.new(
+        periods,
+        TimeSegment.new(origin, terminus)
+      )
     end
 
     def business_hours?(time)

--- a/spec/calculation/duration_within_spec.rb
+++ b/spec/calculation/duration_within_spec.rb
@@ -1,5 +1,7 @@
 RSpec.describe Biz::Calculation::DurationWithin do
-  subject(:calculation) { described_class.new(schedule, calculation_period) }
+  subject(:calculation) {
+    described_class.new(schedule.periods, calculation_period)
+  }
 
   context 'when the calculation start time is after the end time' do
     let(:calculation_period) {

--- a/spec/calculation/for_duration_spec.rb
+++ b/spec/calculation/for_duration_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Biz::Calculation::ForDuration do
-  subject(:calculation) { described_class.new(schedule, duration) }
+  subject(:calculation) { described_class.new(schedule.periods, duration) }
 
   context 'when initializing' do
     context 'with a positive duration' do


### PR DESCRIPTION
For calculations that don't require direct knowledge of the schedule structure for optimization reasons, we should pass periods instead of the schedule itself into the constructor so the calculations can be more easily reused with custom period enumerators.

FWIW, here's yet another good reason why the core calculation logic should be extracted from the business hours configuration and optimizations.

@alex-stone @kruppel 