### PR TITLE
Tweak naming for a couple public methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Or install it yourself as:
 
 ```ruby
 Biz.configure do |config|
-  config.business_hours = {
+  config.hours = {
     mon: {'09:00' => '17:00'},
     tue: {'00:00' => '24:00'},
     wed: {'09:00' => '17:00'},

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Biz.time(2, :hours).after(Time.utc(2015, 12, 25, 9, 30))
 Biz.within(Time.utc(2015, 3, 7), Time.utc(2015, 3, 14)).in_seconds
 
 # Determine if a time is in business hours
-Biz.business_hours?(Time.utc(2015, 1, 10, 9))
+Biz.in_hours?(Time.utc(2015, 1, 10, 9))
 ```
 
 Note that all returned times are in UTC.

--- a/benchmark/speed
+++ b/benchmark/speed
@@ -240,7 +240,7 @@ Benchmark.ips do |bm|
   time = Time.utc(2006, 1, 4, 12)
 
   bm.report 'biz' do
-    Biz.business_hours?(time)
+    Biz.in_hours?(time)
   end
 
   bm.report 'business_time' do
@@ -261,7 +261,7 @@ Benchmark.ips do |bm|
   time = Time.utc(2006, 1, 4, 6)
 
   bm.report 'biz' do
-    Biz.business_hours?(time)
+    Biz.in_hours?(time)
   end
 
   bm.report 'business_time' do

--- a/benchmark/speed
+++ b/benchmark/speed
@@ -19,7 +19,7 @@ holidays = [
 ]
 
 Biz.configure do |config|
-  config.business_hours = {
+  config.hours = {
     mon: {'09:00' => '17:00'},
     tue: {'09:00' => '17:00'},
     wed: {'09:00' => '17:00'},

--- a/lib/biz.rb
+++ b/lib/biz.rb
@@ -24,6 +24,7 @@ module Biz
       periods
       time
       within
+      in_hours?
       business_hours?
     ] => :schedule
 

--- a/lib/biz/configuration.rb
+++ b/lib/biz/configuration.rb
@@ -8,7 +8,7 @@ module Biz
     end
 
     def intervals
-      raw.business_hours.flat_map { |weekday, hours|
+      raw.hours.flat_map { |weekday, hours|
         weekday_intervals(weekday, hours)
       }.sort_by(&:start_time)
     end
@@ -46,28 +46,30 @@ module Biz
     memoize :intervals,
             :holidays
 
-    Raw = Struct.new(:business_hours, :holidays, :time_zone) do
+    Raw = Struct.new(:hours, :holidays, :time_zone) do
       module Default
 
-        BUSINESS_HOURS = {
+        HOURS = {
           mon: {'09:00' => '17:00'},
           tue: {'09:00' => '17:00'},
           wed: {'09:00' => '17:00'},
           thu: {'09:00' => '17:00'},
           fri: {'09:00' => '17:00'}
         }
-        HOLIDAYS       = []
-        TIME_ZONE      = 'Etc/UTC'
+        HOLIDAYS  = []
+        TIME_ZONE = 'Etc/UTC'
 
       end
 
       def initialize(*)
         super
 
-        self.business_hours ||= Default::BUSINESS_HOURS
-        self.holidays       ||= Default::HOLIDAYS
-        self.time_zone      ||= Default::TIME_ZONE
+        self.hours     ||= Default::HOURS
+        self.holidays  ||= Default::HOLIDAYS
+        self.time_zone ||= Default::TIME_ZONE
       end
+
+      alias_method :business_hours=, :hours=
     end
 
   end

--- a/lib/biz/core_ext/time.rb
+++ b/lib/biz/core_ext/time.rb
@@ -3,7 +3,7 @@ module Biz
     module Time
 
       def business_hours?
-        Biz.business_hours?(self)
+        Biz.in_hours?(self)
       end
 
     end

--- a/lib/biz/schedule.rb
+++ b/lib/biz/schedule.rb
@@ -31,9 +31,11 @@ module Biz
       )
     end
 
-    def business_hours?(time)
+    def in_hours?(time)
       Calculation::Active.new(self, time).active?
     end
+
+    alias_method :business_hours?, :in_hours?
 
     protected
 

--- a/script/console
+++ b/script/console
@@ -5,7 +5,7 @@ require 'biz'
 require 'irb'
 
 TEST_SCHEDULE = Biz::Schedule.new do |config|
-  config.business_hours = {
+  config.hours = {
     mon: {'09:00' => '12:00', '13:00' => '17:00'},
     tue: {'09:00' => '12:00', '13:00' => '17:00'},
     wed: {'09:00' => '12:00', '13:00' => '17:00'},

--- a/spec/biz_spec.rb
+++ b/spec/biz_spec.rb
@@ -2,9 +2,9 @@ RSpec.describe Biz do
   context 'when configured' do
     before do
       described_class.configure do |config|
-        config.business_hours = {sun: {'11:00' => '12:00'}}
-        config.holidays       = [Date.new(2015, 12, 25)]
-        config.time_zone      = 'Africa/Abidjan'
+        config.hours     = {sun: {'11:00' => '12:00'}}
+        config.holidays  = [Date.new(2015, 12, 25)]
+        config.time_zone = 'Africa/Abidjan'
       end
     end
 

--- a/spec/biz_spec.rb
+++ b/spec/biz_spec.rb
@@ -73,6 +73,14 @@ RSpec.describe Biz do
       end
     end
 
+    describe '.in_hours?' do
+      it 'delegates to the top-level schedule' do
+        expect(described_class.in_hours?(Time.utc(2006, 1, 1, 11))).to eq(
+          true
+        )
+      end
+    end
+
     describe '.business_hours?' do
       it 'delegates to the top-level schedule' do
         expect(described_class.business_hours?(Time.utc(2006, 1, 1, 11))).to eq(

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Biz::Configuration do
-  let(:business_hours) {
+  let(:hours) {
     {
       mon: {'09:00' => '17:00'},
       tue: {'10:00' => '16:00'},
@@ -14,9 +14,9 @@ RSpec.describe Biz::Configuration do
 
   subject(:configuration) {
     Biz::Configuration.new do |config|
-      config.business_hours = business_hours
-      config.holidays       = holidays
-      config.time_zone      = time_zone
+      config.hours     = hours
+      config.holidays  = holidays
+      config.time_zone = time_zone
     end
   }
 
@@ -39,6 +39,16 @@ RSpec.describe Biz::Configuration do
             )
           }
         )
+      end
+    end
+
+    context 'when configured using #business_hours=' do
+      subject(:configuration) {
+        Biz::Configuration.new do |config| config.business_hours = hours end
+      }
+
+      it 'returns the proper number of intervals' do
+        expect(configuration.intervals.count).to eq 6
       end
     end
 
@@ -78,12 +88,7 @@ RSpec.describe Biz::Configuration do
     end
 
     context 'when the weekdays are configured out of order' do
-      let(:business_hours) {
-        {
-          tue: {'10:00' => '16:00'},
-          mon: {'09:00' => '17:00'}
-        }
-      }
+      let(:hours) { {mon: {'09:00' => '17:00'}, tue: {'10:00' => '16:00'}} }
 
       it 'returns the intervals in order' do
         expect(configuration.intervals).to eq [
@@ -106,8 +111,8 @@ RSpec.describe Biz::Configuration do
     context 'when left unconfigured' do
       subject(:configuration) {
         Biz::Configuration.new do |config|
-          config.business_hours = business_hours
-          config.time_zone      = time_zone
+          config.hours     = hours
+          config.time_zone = time_zone
         end
       }
 
@@ -134,8 +139,8 @@ RSpec.describe Biz::Configuration do
     context 'when left unconfigured' do
       subject(:configuration) {
         Biz::Configuration.new do |config|
-          config.business_hours = business_hours
-          config.holidays       = holidays
+          config.hours    = hours
+          config.holidays = holidays
         end
       }
 

--- a/spec/core_ext/date_spec.rb
+++ b/spec/core_ext/date_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe Biz::CoreExt::Date do
 
   before do
     Biz.configure do |config|
-      config.business_hours  = {mon: {'09:00' => '17:00'}}
-      config.holidays        = []
-      config.time_zone       = 'Etc/UTC'
+      config.hours     = {mon: {'09:00' => '17:00'}}
+      config.holidays  = []
+      config.time_zone = 'Etc/UTC'
     end
   end
 

--- a/spec/core_ext/fixnum_spec.rb
+++ b/spec/core_ext/fixnum_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe Biz::CoreExt::Fixnum do
 
   before do
     Biz.configure do |config|
-      config.business_hours  = {mon: {'09:00' => '17:00'}}
-      config.holidays        = []
-      config.time_zone       = 'Etc/UTC'
+      config.hours     = {mon: {'09:00' => '17:00'}}
+      config.holidays  = []
+      config.time_zone = 'Etc/UTC'
     end
   end
 

--- a/spec/core_ext/time_spec.rb
+++ b/spec/core_ext/time_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe Biz::CoreExt::Time do
 
   before do
     Biz.configure do |config|
-      config.business_hours  = {mon: {'09:00' => '17:00'}}
-      config.holidays        = []
-      config.time_zone       = 'Etc/UTC'
+      config.hours     = {mon: {'09:00' => '17:00'}}
+      config.holidays  = []
+      config.time_zone = 'Etc/UTC'
     end
   end
 

--- a/spec/periods/after_spec.rb
+++ b/spec/periods/after_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Biz::Periods::After do
-  let(:business_hours) {
+  let(:hours) {
     {
       mon: {'09:00' => '17:00'},
       tue: {'10:00' => '16:00'},
@@ -16,11 +16,7 @@ RSpec.describe Biz::Periods::After do
 
   subject(:periods) {
     described_class.new(
-      schedule(
-        business_hours: business_hours,
-        holidays:       holidays,
-        time_zone:      time_zone
-      ),
+      schedule(hours: hours, holidays: holidays, time_zone: time_zone),
       origin
     )
   }
@@ -174,8 +170,8 @@ RSpec.describe Biz::Periods::After do
   end
 
   context 'when the origin is near the beginning of the week' do
-    let(:business_hours) { {sat: {'06:00' => '18:00'}} }
-    let(:time_zone)      { 'America/Los_Angeles' }
+    let(:hours)     { {sat: {'06:00' => '18:00'}} }
+    let(:time_zone) { 'America/Los_Angeles' }
 
     let(:origin) {
       in_zone('America/Los_Angeles') { Time.utc(2006, 1, 7, 17) }

--- a/spec/periods/before_spec.rb
+++ b/spec/periods/before_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Biz::Periods::Before do
-  let(:business_hours) {
+  let(:hours) {
     {
       mon: {'09:00' => '17:00'},
       tue: {'10:00' => '16:00'},
@@ -16,11 +16,7 @@ RSpec.describe Biz::Periods::Before do
 
   subject(:periods) {
     described_class.new(
-      schedule(
-        business_hours: business_hours,
-        holidays:       holidays,
-        time_zone:      time_zone
-      ),
+      schedule(hours: hours, holidays: holidays, time_zone: time_zone),
       origin
     )
   }
@@ -174,12 +170,10 @@ RSpec.describe Biz::Periods::Before do
   end
 
   context 'when the origin is near the end of the week' do
-    let(:business_hours) { {sun: {'06:00' => '18:00'}} }
-    let(:time_zone)      { 'Asia/Brunei' }
+    let(:hours)     { {sun: {'06:00' => '18:00'}} }
+    let(:time_zone) { 'Asia/Brunei' }
 
-    let(:origin) {
-      in_zone('Asia/Brunei') { Time.utc(2006, 1, 8, 7) }
-    }
+    let(:origin) { in_zone('Asia/Brunei') { Time.utc(2006, 1, 8, 7) } }
 
     it 'includes the relevant interval from the prior week' do
       expect(periods.first).to eq(

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Biz::Schedule do
-  let(:business_hours) {
+  let(:hours) {
     {
       mon: {'09:00' => '17:00'},
       tue: {'10:00' => '16:00'},
@@ -13,9 +13,9 @@ RSpec.describe Biz::Schedule do
   let(:time_zone) { 'Etc/UTC' }
   let(:config)    {
     proc do |c|
-      c.business_hours = business_hours
-      c.holidays       = holidays
-      c.time_zone      = time_zone
+      c.hours     = hours
+      c.holidays  = holidays
+      c.time_zone = time_zone
     end
   }
 

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -65,6 +65,24 @@ RSpec.describe Biz::Schedule do
     end
   end
 
+  describe '#in_hours?' do
+    context 'when the time is not in business hours' do
+      let(:time) { Time.utc(2006, 1, 2, 8) }
+
+      it 'returns false' do
+        expect(schedule.in_hours?(time)).to eq false
+      end
+    end
+
+    context 'when the time is in business hours' do
+      let(:time) { Time.utc(2006, 1, 2, 10) }
+
+      it 'returns true' do
+        expect(schedule.in_hours?(time)).to eq true
+      end
+    end
+  end
+
   describe '#business_hours?' do
     context 'when the time is not in business hours' do
       let(:time) { Time.utc(2006, 1, 2, 8) }

--- a/spec/support/time.rb
+++ b/spec/support/time.rb
@@ -54,7 +54,7 @@ module Biz
 
       def schedule(args = {})
         Biz::Schedule.new do |config|
-          config.business_hours = args.fetch(:business_hours,
+          config.hours = args.fetch(:hours,
             mon: {'09:00' => '17:00'},
             tue: {'10:00' => '16:00'},
             wed: {'09:00' => '17:00'},


### PR DESCRIPTION
These are a couple of small warts that I instantly regretted after putting out `v1.0.0`. Might as well fix it up now. The replaced methods will be considered deprecated and removed in `v2.0.0`.

@alex-stone @kruppel 