### PR TITLE
Remove 'day' as a unit of duration

### DIFF
--- a/lib/biz/duration.rb
+++ b/lib/biz/duration.rb
@@ -1,7 +1,7 @@
 module Biz
   class Duration
 
-    UNITS = Set.new(%i[second seconds minute minutes hour hours day days])
+    UNITS = Set.new(%i[second seconds minute minutes hour hours])
 
     include Equalizer.new(:seconds)
     include Comparable
@@ -36,12 +36,6 @@ module Biz
 
       alias_method :hour, :hours
 
-      def days(days)
-        new(days * Time::DAY)
-      end
-
-      alias_method :day, :days
-
     end
 
     attr_reader :seconds
@@ -62,10 +56,6 @@ module Biz
 
     def in_hours
       seconds / Time::HOUR
-    end
-
-    def in_days
-      seconds / Time::DAY
     end
 
     def +(other)

--- a/spec/duration_spec.rb
+++ b/spec/duration_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe Biz::Duration do
   describe '#with_unit' do
     context 'when called with a supported unit' do
       it 'returns the proper duration' do
-        expect(described_class.with_unit(1, :day)).to eq(
-          described_class.days(1)
+        expect(described_class.with_unit(1, :hour)).to eq(
+          described_class.hours(1)
         )
       end
     end
@@ -95,22 +95,6 @@ RSpec.describe Biz::Duration do
     end
   end
 
-  describe '.days' do
-    it 'returns the proper duration' do
-      expect(described_class.days(1)).to eq(
-        described_class.new(in_seconds(days: 1))
-      )
-    end
-  end
-
-  describe '.day' do
-    it 'returns the proper duration' do
-      expect(described_class.day(1)).to eq(
-        described_class.new(in_seconds(days: 1))
-      )
-    end
-  end
-
   describe '#in_seconds' do
     it 'returns the number of seconds' do
       expect(duration.in_seconds).to eq(
@@ -128,12 +112,6 @@ RSpec.describe Biz::Duration do
   describe '#in_hours' do
     it 'returns the number of whole hours' do
       expect(duration.in_hours).to eq 2 * 24 + 5
-    end
-  end
-
-  describe '#in_days' do
-    it 'returns the number of whole days' do
-      expect(duration.in_days).to eq 2
     end
   end
 

--- a/spec/timeline/backward_spec.rb
+++ b/spec/timeline/backward_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Biz::Timeline::Backward do
     end
 
     context 'when the duration is contained by the first period' do
-      let(:duration) { Biz::Duration.days(15) }
+      let(:duration) { Biz::Duration.seconds(in_seconds(days: 15)) }
 
       it 'returns part of the first period' do
         expect(timeline.for(duration).to_a).to eq [
@@ -114,7 +114,7 @@ RSpec.describe Biz::Timeline::Backward do
     end
 
     context 'when the duration is the length of the first period' do
-      let(:duration) { Biz::Duration.days(31) }
+      let(:duration) { Biz::Duration.seconds(in_seconds(days: 31)) }
 
       it 'returns the first period' do
         expect(timeline.for(duration).to_a).to eq [
@@ -124,7 +124,7 @@ RSpec.describe Biz::Timeline::Backward do
     end
 
     context 'when the duration is contained by a set of full periods' do
-      let(:duration) { Biz::Duration.days(62) }
+      let(:duration) { Biz::Duration.seconds(in_seconds(days: 62)) }
 
       it 'returns the proper periods' do
         expect(timeline.for(duration).to_a).to eq [
@@ -135,7 +135,7 @@ RSpec.describe Biz::Timeline::Backward do
     end
 
     context 'when the duration ends in the middle of a period' do
-      let(:duration) { Biz::Duration.days(46) }
+      let(:duration) { Biz::Duration.seconds(in_seconds(days: 46)) }
 
       it 'returns the proper periods' do
         expect(timeline.for(duration).to_a).to eq [

--- a/spec/timeline/forward_spec.rb
+++ b/spec/timeline/forward_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Biz::Timeline::Forward do
     end
 
     context 'when the duration is contained by the first period' do
-      let(:duration) { Biz::Duration.days(15) }
+      let(:duration) { Biz::Duration.seconds(in_seconds(days: 15)) }
 
       it 'returns part of the first period' do
         expect(timeline.for(duration).to_a).to eq [
@@ -112,7 +112,7 @@ RSpec.describe Biz::Timeline::Forward do
     end
 
     context 'when the duration is the length of the first period' do
-      let(:duration) { Biz::Duration.days(31) }
+      let(:duration) { Biz::Duration.seconds(in_seconds(days: 31)) }
 
       it 'returns the first period' do
         expect(timeline.for(duration).to_a).to eq [
@@ -122,7 +122,7 @@ RSpec.describe Biz::Timeline::Forward do
     end
 
     context 'when the duration is contained by a set of full periods' do
-      let(:duration) { Biz::Duration.days(62) }
+      let(:duration) { Biz::Duration.seconds(in_seconds(days: 62)) }
 
       it 'returns the proper periods' do
         expect(timeline.for(duration).to_a).to eq [
@@ -133,7 +133,7 @@ RSpec.describe Biz::Timeline::Forward do
     end
 
     context 'when the duration ends in the middle of a period' do
-      let(:duration) { Biz::Duration.days(46) }
+      let(:duration) { Biz::Duration.seconds(in_seconds(days: 46)) }
 
       it 'returns the proper periods' do
         expect(timeline.for(duration).to_a).to eq [


### PR DESCRIPTION
Unlike seconds, minutes, and hours, the length of a day is a somewhat nebulous concept that can depend on quirks like DST. Users who specify this duration probably aren't getting what they think they're getting, particularly with calculations like:

```ruby
Biz.time(2, :days).after(Time.now)
```

The above calculation will return the time 48 business hours after the specified starting time, and thus, operates primarily as an alias for an hours-based calculation. This doesn't really add much value and can only sow confusion.

We have a more sensible day-based time calculation in the works, but until that's available, let's do away with the capability for using this misleading duration.

@alex-stone @kruppel 