### PR TITLE
Implement day-increment duration calculations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,9 @@ AllCops:
     - 'bin/**/*'
     - 'vendor/**/*'
 
+Metrics/AbcSize:
+  Enabled: false
+
 Metrics/LineLength:
   Exclude:
     - 'Gemfile'
@@ -31,6 +34,9 @@ Style/EmptyLinesAroundClassBody:
   Enabled: false
 
 Style/EmptyLinesAroundModuleBody:
+  Enabled: false
+
+Style/Lambda:
   Enabled: false
 
 Style/MultilineBlockChain:

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ Biz.time(30, :minutes).before(Time.utc(2015, 1, 1, 11, 45))
 # Find the time an amount of business time *after* a specified starting time
 Biz.time(2, :hours).after(Time.utc(2015, 12, 25, 9, 30))
 
+# Calculations can be performed in seconds, minutes, hours, or days
+Biz.time(1, :day).after(Time.utc(2015, 1, 8, 10))
+
 # Find the amount of business time between two times
 Biz.within(Time.utc(2015, 3, 7), Time.utc(2015, 3, 14)).in_seconds
 
@@ -90,9 +93,7 @@ which you can use to do your own custom calculations or just get a better idea
 of what's happening under the hood:
 
 ```ruby
-Biz.periods
-  .after(Time.utc(2015, 1, 10, 10))
-  .timeline.forward
+Biz.periods.after(Time.utc(2015, 1, 10, 10)).timeline
   .until(Time.utc(2015, 1, 17, 10)).to_a
 
 #=> [#<Biz::TimeSegment start_time=2015-01-10 18:00:00 UTC end_time=2015-01-10 22:00:00 UTC>,
@@ -103,8 +104,7 @@ Biz.periods
 #  #<Biz::TimeSegment start_time=2015-01-15 21:00:00 UTC end_time=2015-01-16 01:00:00 UTC>]
 
 Biz.periods
-  .before(Time.utc(2015, 5, 5, 12, 34, 57))
-  .timeline.backward
+  .before(Time.utc(2015, 5, 5, 12, 34, 57)).timeline
   .for(Biz::Duration.minutes(3_598)).to_a
 
 #=> [#<Biz::TimeSegment start_time=2015-05-05 07:00:00 UTC end_time=2015-05-05 12:34:57 UTC>,

--- a/biz.gemspec
+++ b/biz.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 2.0'
 
   gem.add_runtime_dependency 'abstract_type', '~> 0.0.0'
+  gem.add_runtime_dependency 'clavius',       '~> 1.0'
   gem.add_runtime_dependency 'equalizer',     '~> 0.0.0'
   gem.add_runtime_dependency 'memoizable',    '~> 0.4.0'
   gem.add_runtime_dependency 'tzinfo'

--- a/lib/biz.rb
+++ b/lib/biz.rb
@@ -13,8 +13,8 @@ module Biz
 
     extend Forwardable
 
-    def configure(&block)
-      Thread.current[:biz_schedule] = Schedule.new(&block)
+    def configure(&config)
+      Thread.current[:biz_schedule] = Schedule.new(&config)
     end
 
     delegate %i[

--- a/lib/biz.rb
+++ b/lib/biz.rb
@@ -4,6 +4,7 @@ require 'forwardable'
 require 'set'
 
 require 'abstract_type'
+require 'clavius'
 require 'equalizer'
 require 'memoizable'
 require 'tzinfo'
@@ -22,6 +23,8 @@ module Biz
       holidays
       time_zone
       periods
+      date
+      dates
       time
       within
       in_hours?
@@ -37,13 +40,12 @@ module Biz
   end
 end
 
-require 'biz/version'
-
 require 'biz/date'
 require 'biz/time'
 
 require 'biz/calculation'
 require 'biz/configuration'
+require 'biz/dates'
 require 'biz/day'
 require 'biz/day_of_week'
 require 'biz/day_time'
@@ -56,3 +58,4 @@ require 'biz/timeline'
 require 'biz/time_segment'
 require 'biz/week'
 require 'biz/week_time'
+require 'biz/version'

--- a/lib/biz/calculation/active.rb
+++ b/lib/biz/calculation/active.rb
@@ -7,7 +7,7 @@ module Biz
         @time     = time
       end
 
-      def active?
+      def result
         schedule.intervals.any? { |interval| interval.contains?(time) } &&
           schedule.holidays.none? { |holiday| holiday.contains?(time) }
       end

--- a/lib/biz/calculation/active.rb
+++ b/lib/biz/calculation/active.rb
@@ -2,9 +2,6 @@ module Biz
   module Calculation
     class Active
 
-      attr_reader :schedule,
-                  :time
-
       def initialize(schedule, time)
         @schedule = schedule
         @time     = time
@@ -14,6 +11,11 @@ module Biz
         schedule.intervals.any? { |interval| interval.contains?(time) } &&
           schedule.holidays.none? { |holiday| holiday.contains?(time) }
       end
+
+      protected
+
+      attr_reader :schedule,
+                  :time
 
     end
   end

--- a/lib/biz/calculation/duration_within.rb
+++ b/lib/biz/calculation/duration_within.rb
@@ -2,10 +2,9 @@ module Biz
   module Calculation
     class DurationWithin < SimpleDelegator
 
-      def initialize(periods, calculation_period)
+      def initialize(schedule, calculation_period)
         super(
-          periods.after(calculation_period.start_time)
-            .timeline.forward
+          schedule.periods.after(calculation_period.start_time).timeline
             .until(calculation_period.end_time)
             .map(&:duration)
             .reduce(Duration.new(0), :+)

--- a/lib/biz/calculation/for_duration.rb
+++ b/lib/biz/calculation/for_duration.rb
@@ -2,30 +2,104 @@ module Biz
   module Calculation
     class ForDuration
 
-      attr_reader :periods,
-                  :duration
+      UNITS = Set.new(%i[second seconds minute minutes hour hours day days])
 
-      def initialize(periods, duration)
-        unless duration.positive?
-          fail ArgumentError, 'Duration adjustment must be positive.'
+      include AbstractType
+
+      def self.with_unit(schedule, scalar, unit)
+        unless UNITS.include?(unit)
+          fail ArgumentError, 'The unit is not supported.'
         end
 
-        @periods  = periods
-        @duration = duration
+        send(unit, schedule, scalar)
       end
 
-      def before(time)
-        periods.before(time)
-          .timeline.backward
-          .for(duration).to_a
-          .last.start_time
+      def self.unit
+        name.split('::').last.downcase.to_sym
       end
 
-      def after(time)
-        periods.after(time)
-          .timeline.forward
-          .for(duration).to_a
-          .last.end_time
+      def initialize(schedule, scalar)
+        @schedule = schedule
+        @scalar   = scalar
+      end
+
+      abstract_method :before,
+                      :after
+
+      protected
+
+      attr_reader :schedule,
+                  :scalar
+
+      private
+
+      def unit
+        self.class.unit
+      end
+
+      [
+        *%i[second seconds minute minutes hour hours].map { |unit|
+          const_set(unit.to_s.capitalize,
+            Class.new(self) do
+              def before(time)
+                timeline(:before, time).last.start_time
+              end
+
+              def after(time)
+                timeline(:after, time).last.end_time
+              end
+
+              private
+
+              def timeline(direction, time)
+                schedule.periods.send(direction, time).timeline
+                  .for(duration).to_a
+              end
+
+              def duration
+                Duration.send(unit, scalar)
+              end
+            end
+          )
+        },
+        *%i[day days].map { |unit|
+          const_set(unit.to_s.capitalize,
+            Class.new(self) do
+              def before(time)
+                periods(:before, time).first.end_time
+              end
+
+              def after(time)
+                periods(:after, time).first.start_time
+              end
+
+              private
+
+              def periods(direction, time)
+                schedule.periods.send(direction, advanced_date(direction, time))
+              end
+
+              def advanced_date(direction, time)
+                schedule.in_zone.on_date(
+                  schedule.dates.days(scalar).send(direction, local(time)),
+                  day_time(time)
+                )
+              end
+
+              def day_time(time)
+                DayTime.from_time(local(time))
+              end
+
+              def local(time)
+                schedule.in_zone.local(time)
+              end
+            end
+          )
+        }
+      ].each do |unit_class|
+        define_singleton_method(unit_class.unit) { |schedule, scalar|
+          unit_class.new(schedule, scalar)
+        }
       end
 
     end

--- a/lib/biz/configuration.rb
+++ b/lib/biz/configuration.rb
@@ -21,6 +21,10 @@ module Biz
       TZInfo::TimezoneProxy.new(raw.time_zone)
     end
 
+    def weekdays
+      raw.hours.keys.to_set
+    end
+
     protected
 
     attr_reader :raw
@@ -44,7 +48,8 @@ module Biz
     end
 
     memoize :intervals,
-            :holidays
+            :holidays,
+            :weekdays
 
     Raw = Struct.new(:hours, :holidays, :time_zone) do
       module Default

--- a/lib/biz/configuration.rb
+++ b/lib/biz/configuration.rb
@@ -4,7 +4,7 @@ module Biz
     include Memoizable
 
     def initialize
-      @raw = Raw.new.tap do |raw| yield raw end
+      @raw = Raw.new.tap do |raw| yield raw if block_given? end
     end
 
     def intervals

--- a/lib/biz/core_ext/date.rb
+++ b/lib/biz/core_ext/date.rb
@@ -3,11 +3,7 @@ module Biz
     module Date
 
       def business_day?
-        Biz.periods
-          .after(Biz::Time.new(Biz.time_zone).on_date(self, DayTime.midnight))
-          .timeline.forward
-          .until(Biz::Time.new(Biz.time_zone).on_date(self, DayTime.endnight))
-          .any?
+        Biz.dates.active?(self)
       end
 
     end

--- a/lib/biz/core_ext/fixnum.rb
+++ b/lib/biz/core_ext/fixnum.rb
@@ -2,7 +2,7 @@ module Biz
   module CoreExt
     module Fixnum
 
-      %i[second seconds minute minutes hour hours].each do |unit|
+      Calculation::ForDuration::UNITS.each do |unit|
         define_method("business_#{unit}") { Biz.time(self, unit) }
       end
 

--- a/lib/biz/dates.rb
+++ b/lib/biz/dates.rb
@@ -1,0 +1,14 @@
+module Biz
+  class Dates < SimpleDelegator
+
+    def initialize(schedule)
+      super(
+        Clavius::Schedule.new do |c|
+          c.weekdays = schedule.weekdays
+          c.excluded = schedule.holidays.map(&:date)
+        end
+      )
+    end
+
+  end
+end

--- a/lib/biz/day_time.rb
+++ b/lib/biz/day_time.rb
@@ -8,33 +8,37 @@ module Biz
 
     extend Forwardable
 
-    def self.from_hour(hour)
-      new(hour * Time::MINUTES_IN_HOUR)
-    end
-
-    def self.from_timestamp(timestamp)
-      timestamp.match(TIMESTAMP_PATTERN) { |match|
-        new(match[:hour].to_i * Time::MINUTES_IN_HOUR + match[:minute].to_i)
-      }
-    end
-
-    def self.midnight
-      MIDNIGHT
-    end
-
-    def self.noon
-      NOON
-    end
-
-    def self.endnight
-      ENDNIGHT
-    end
-
     class << self
+
+      def from_time(time)
+        new(time.hour * Time::MINUTES_IN_HOUR + time.min)
+      end
+
+      def from_hour(hour)
+        new(hour * Time::MINUTES_IN_HOUR)
+      end
+
+      def from_timestamp(timestamp)
+        timestamp.match(TIMESTAMP_PATTERN) { |match|
+          new(match[:hour].to_i * Time::MINUTES_IN_HOUR + match[:minute].to_i)
+        }
+      end
+
+      def midnight
+        MIDNIGHT
+      end
 
       alias_method :am, :midnight
 
+      def noon
+        NOON
+      end
+
       alias_method :pm, :noon
+
+      def endnight
+        ENDNIGHT
+      end
 
     end
 

--- a/lib/biz/duration.rb
+++ b/lib/biz/duration.rb
@@ -1,22 +1,12 @@
 module Biz
   class Duration
 
-    UNITS = Set.new(%i[second seconds minute minutes hour hours])
-
     include Equalizer.new(:seconds)
     include Comparable
 
     extend Forwardable
 
     class << self
-
-      def with_unit(scalar, unit)
-        unless UNITS.include?(unit)
-          fail ArgumentError, 'The unit is not supported.'
-        end
-
-        public_send(unit, scalar)
-      end
 
       def seconds(seconds)
         new(seconds)

--- a/lib/biz/holiday.rb
+++ b/lib/biz/holiday.rb
@@ -22,5 +22,7 @@ module Biz
       )
     end
 
+    alias_method :to_date, :date
+
   end
 end

--- a/lib/biz/periods.rb
+++ b/lib/biz/periods.rb
@@ -1,8 +1,6 @@
 module Biz
   class Periods
 
-    attr_reader :schedule
-
     def initialize(schedule)
       @schedule = schedule
     end
@@ -14,6 +12,10 @@ module Biz
     def before(origin)
       Before.new(schedule, origin)
     end
+
+    protected
+
+    attr_reader :schedule
 
   end
 end

--- a/lib/biz/periods/abstract.rb
+++ b/lib/biz/periods/abstract.rb
@@ -4,9 +4,6 @@ module Biz
 
       extend Forwardable
 
-      attr_reader :schedule,
-                  :origin
-
       def initialize(schedule, origin)
         @schedule = schedule
         @origin   = origin
@@ -19,6 +16,11 @@ module Biz
       def timeline
         Timeline.new(self)
       end
+
+      protected
+
+      attr_reader :schedule,
+                  :origin
 
       private
 

--- a/lib/biz/periods/after.rb
+++ b/lib/biz/periods/after.rb
@@ -2,6 +2,10 @@ module Biz
   class Periods
     class After < Abstract
 
+      def timeline
+        super.forward
+      end
+
       private
 
       def weeks

--- a/lib/biz/periods/before.rb
+++ b/lib/biz/periods/before.rb
@@ -2,6 +2,10 @@ module Biz
   class Periods
     class Before < Abstract
 
+      def timeline
+        super.backward
+      end
+
       private
 
       def weeks

--- a/lib/biz/schedule.rb
+++ b/lib/biz/schedule.rb
@@ -32,7 +32,7 @@ module Biz
     end
 
     def in_hours?(time)
-      Calculation::Active.new(self, time).active?
+      Calculation::Active.new(self, time).result
     end
 
     alias_method :business_hours?, :in_hours?

--- a/lib/biz/schedule.rb
+++ b/lib/biz/schedule.rb
@@ -11,11 +11,18 @@ module Biz
       intervals
       holidays
       time_zone
+      weekdays
     ] => :configuration
 
     def periods
       Periods.new(self)
     end
+
+    def dates
+      Dates.new(self)
+    end
+
+    alias_method :date, :dates
 
     def time(scalar, unit)
       Calculation::ForDuration.new(

--- a/lib/biz/schedule.rb
+++ b/lib/biz/schedule.rb
@@ -25,17 +25,11 @@ module Biz
     alias_method :date, :dates
 
     def time(scalar, unit)
-      Calculation::ForDuration.new(
-        periods,
-        Duration.with_unit(scalar, unit)
-      )
+      Calculation::ForDuration.with_unit(self, scalar, unit)
     end
 
     def within(origin, terminus)
-      Calculation::DurationWithin.new(
-        periods,
-        TimeSegment.new(origin, terminus)
-      )
+      Calculation::DurationWithin.new(self, TimeSegment.new(origin, terminus))
     end
 
     def in_hours?(time)
@@ -43,6 +37,10 @@ module Biz
     end
 
     alias_method :business_hours?, :in_hours?
+
+    def in_zone
+      Time.new(time_zone)
+    end
 
     protected
 

--- a/lib/biz/schedule.rb
+++ b/lib/biz/schedule.rb
@@ -3,8 +3,8 @@ module Biz
 
     extend Forwardable
 
-    def initialize(&block)
-      @configuration = Configuration.new(&block)
+    def initialize(&config)
+      @configuration = Configuration.new(&config)
     end
 
     delegate %i[

--- a/lib/biz/timeline.rb
+++ b/lib/biz/timeline.rb
@@ -1,8 +1,6 @@
 module Biz
   class Timeline
 
-    attr_reader :periods
-
     def initialize(periods)
       @periods = periods
     end
@@ -14,6 +12,10 @@ module Biz
     def backward
       Backward.new(periods)
     end
+
+    protected
+
+    attr_reader :periods
 
   end
 end

--- a/lib/biz/timeline/abstract.rb
+++ b/lib/biz/timeline/abstract.rb
@@ -2,8 +2,6 @@ module Biz
   class Timeline
     class Abstract
 
-      attr_reader :periods
-
       def initialize(periods)
         @periods = periods.lazy
       end
@@ -35,6 +33,10 @@ module Biz
           break unless remaining.positive?
         end
       end
+
+      protected
+
+      attr_reader :periods
 
     end
   end

--- a/lib/biz/timeline/backward.rb
+++ b/lib/biz/timeline/backward.rb
@@ -2,6 +2,10 @@ module Biz
   class Timeline
     class Backward < Abstract
 
+      def backward
+        self
+      end
+
       private
 
       def occurred?(period, time)

--- a/lib/biz/timeline/forward.rb
+++ b/lib/biz/timeline/forward.rb
@@ -2,6 +2,10 @@ module Biz
   class Timeline
     class Forward < Abstract
 
+      def forward
+        self
+      end
+
       private
 
       def occurred?(period, time)

--- a/spec/biz_spec.rb
+++ b/spec/biz_spec.rb
@@ -54,6 +54,16 @@ RSpec.describe Biz do
       end
     end
 
+    %i[date dates].each do |method|
+      describe ".#{method}" do
+        it 'delegates to the top-level schedule' do
+          expect(described_class.dates.after(Date.new(2006, 1, 1)).first).to eq(
+            Date.new(2006, 1, 8)
+          )
+        end
+      end
+    end
+
     describe '.time' do
       it 'delegates to the top-level schedule' do
         expect(

--- a/spec/calculation/active_spec.rb
+++ b/spec/calculation/active_spec.rb
@@ -3,13 +3,13 @@ RSpec.describe Biz::Calculation::Active do
     described_class.new(schedule(holidays: [Date.new(2006, 1, 4)]), time)
   }
 
-  describe '#active?' do
+  describe '#result' do
     context 'when the time is not contained by an interval' do
       context 'and not on a holiday' do
         let(:time) { Time.utc(2006, 1, 1, 6) }
 
         it 'returns false' do
-          expect(calculation.active?).to eq false
+          expect(calculation.result).to eq false
         end
       end
 
@@ -17,7 +17,7 @@ RSpec.describe Biz::Calculation::Active do
         let(:time) { Time.utc(2006, 1, 4, 6) }
 
         it 'returns false' do
-          expect(calculation.active?).to eq false
+          expect(calculation.result).to eq false
         end
       end
     end
@@ -27,7 +27,7 @@ RSpec.describe Biz::Calculation::Active do
         let(:time) { Time.utc(2006, 1, 2, 12) }
 
         it 'returns true' do
-          expect(calculation.active?).to eq true
+          expect(calculation.result).to eq true
         end
       end
 
@@ -35,7 +35,7 @@ RSpec.describe Biz::Calculation::Active do
         let(:time) { Time.utc(2006, 1, 4, 12) }
 
         it 'returns false' do
-          expect(calculation.active?).to eq false
+          expect(calculation.result).to eq false
         end
       end
     end

--- a/spec/calculation/duration_within_spec.rb
+++ b/spec/calculation/duration_within_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Biz::Calculation::DurationWithin do
   subject(:calculation) {
-    described_class.new(schedule.periods, calculation_period)
+    described_class.new(schedule, calculation_period)
   }
 
   context 'when the calculation start time is after the end time' do

--- a/spec/calculation/for_duration_spec.rb
+++ b/spec/calculation/for_duration_spec.rb
@@ -1,47 +1,147 @@
 RSpec.describe Biz::Calculation::ForDuration do
-  subject(:calculation) { described_class.new(schedule.periods, duration) }
-
-  context 'when initializing' do
-    context 'with a positive duration' do
-      it 'is successful' do
-        expect(described_class.new([], Biz::Duration.hour(1)).duration).to eq(
-          Biz::Duration.hour(1)
+  describe '#with_unit' do
+    context 'when called with a supported unit' do
+      it 'returns a calculation with the unit' do
+        expect(
+          described_class
+            .with_unit(schedule, 1, :hour)
+            .after(Time.utc(2006, 1, 2, 10))
+        ).to eq(
+          described_class.hours(schedule, 1).after(Time.utc(2006, 1, 2, 10))
         )
       end
     end
 
-    context 'with a negative duration' do
+    context 'when called with an unsupported unit' do
       it 'fails hard' do
         expect {
-          described_class.new([], Biz::Duration.hour(-1))
-        }.to raise_error ArgumentError
-      end
-    end
-
-    context 'with a zero duration' do
-      it 'fails hard' do
-        expect {
-          described_class.new([], Biz::Duration.hour(0))
+          described_class.with_unit(schedule, 1, :parsec)
         }.to raise_error ArgumentError
       end
     end
   end
 
-  describe '#before' do
-    let(:duration) { Biz::Duration.hours(19) }
-    let(:time)     { Time.utc(2006, 1, 4, 16) }
+  %i[second seconds].each do |unit|
+    describe ".#{unit}" do
+      subject(:calculation) { described_class.send(unit, schedule, 90) }
 
-    it 'returns the backward time after the elapsed duration' do
-      expect(calculation.before(time)).to eq Time.utc(2006, 1, 2, 11)
+      describe '#before' do
+        let(:time) { Time.utc(2006, 1, 4, 16, 1, 30) }
+
+        it 'returns the backward time after the elapsed duration' do
+          expect(calculation.before(time)).to eq Time.utc(2006, 1, 4, 16)
+        end
+      end
+
+      describe '#after' do
+        let(:time) { Time.utc(2006, 1, 4, 15, 58, 30) }
+
+        it 'returns the forward time after the elapsed duration' do
+          expect(calculation.after(time)).to eq Time.utc(2006, 1, 4, 16)
+        end
+      end
     end
   end
 
-  describe '#after' do
-    let(:duration) { Biz::Duration.hours(19) }
-    let(:time)     { Time.utc(2006, 1, 2, 11) }
+  %i[minute minutes].each do |unit|
+    describe ".#{unit}" do
+      subject(:calculation) { described_class.send(unit, schedule, 90) }
 
-    it 'returns the forward time after the elapsed duration' do
-      expect(calculation.after(time)).to eq Time.utc(2006, 1, 4, 16)
+      describe '#before' do
+        let(:time) { Time.utc(2006, 1, 4, 16, 30) }
+
+        it 'returns the backward time after the elapsed duration' do
+          expect(calculation.before(time)).to eq Time.utc(2006, 1, 4, 15)
+        end
+      end
+
+      describe '#after' do
+        let(:time) { Time.utc(2006, 1, 4, 15, 30) }
+
+        it 'returns the forward time after the elapsed duration' do
+          expect(calculation.after(time)).to eq Time.utc(2006, 1, 4, 17)
+        end
+      end
+    end
+  end
+
+  %i[hour hours].each do |unit|
+    describe ".#{unit}" do
+      subject(:calculation) { described_class.send(unit, schedule, 3) }
+
+      describe '#before' do
+        let(:time) { Time.utc(2006, 1, 4, 17) }
+
+        it 'returns the backward time after the elapsed duration' do
+          expect(calculation.before(time)).to eq Time.utc(2006, 1, 4, 14)
+        end
+      end
+
+      describe '#after' do
+        let(:time) { Time.utc(2006, 1, 4, 14) }
+
+        it 'returns the forward time after the elapsed duration' do
+          expect(calculation.after(time)).to eq Time.utc(2006, 1, 4, 17)
+        end
+      end
+    end
+  end
+
+  %i[day days].each do |unit|
+    describe ".#{unit}" do
+      subject(:calculation) { described_class.send(unit, schedule, 2) }
+
+      describe '#before' do
+        context 'when the advanced time is within a period' do
+          let(:time) { Time.utc(2006, 1, 9, 12) }
+
+          it 'returns the time advanced by the number of business days' do
+            expect(calculation.before(time)).to eq Time.utc(2006, 1, 6, 12)
+          end
+        end
+
+        context 'when the advanced time is before the first day period' do
+          let(:time) { Time.utc(2006, 1, 5, 8) }
+
+          it 'returns the next time before the advanced time' do
+            expect(calculation.before(time)).to eq Time.utc(2006, 1, 2, 17)
+          end
+        end
+
+        context 'when the advanced time is after the last day period' do
+          let(:time) { Time.utc(2006, 1, 5, 18) }
+
+          it 'returns the next time before the advanced time' do
+            expect(calculation.before(time)).to eq Time.utc(2006, 1, 3, 16)
+          end
+        end
+      end
+
+      describe '#after' do
+        context 'when the advanced time is within a period' do
+          let(:time) { Time.utc(2006, 1, 6, 12) }
+
+          it 'returns the time advanced by the number of business days' do
+            expect(calculation.after(time)).to eq Time.utc(2006, 1, 9, 12)
+          end
+        end
+
+        context 'when the advanced time is before the first day period' do
+          let(:time) { Time.utc(2006, 1, 3, 8) }
+
+          it 'returns the next time after the advanced time' do
+            expect(calculation.after(time)).to eq Time.utc(2006, 1, 5, 10)
+          end
+        end
+
+        context 'when the advanced time is after the last day period' do
+          let(:time) { Time.utc(2006, 1, 3, 18) }
+
+          it 'returns the next time after the advanced time' do
+            expect(calculation.after(time)).to eq Time.utc(2006, 1, 6, 9)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -161,4 +161,10 @@ RSpec.describe Biz::Configuration do
       )
     end
   end
+
+  describe '#weekdays' do
+    it 'returns the active weekdays for the configured schedule' do
+      expect(configuration.weekdays).to eq Set.new(%i[mon tue wed thu fri sat])
+    end
+  end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -20,6 +20,12 @@ RSpec.describe Biz::Configuration do
     end
   }
 
+  context 'when initialized without a block' do
+    it 'does not blow up' do
+      expect { described_class.new }.not_to raise_error
+    end
+  end
+
   describe '#intervals' do
     context 'when left unconfigured' do
       subject(:configuration) {

--- a/spec/dates_spec.rb
+++ b/spec/dates_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe Biz::Dates do
+  subject(:dates) {
+    described_class.new(
+      schedule(
+        hours:    {mon: {'01:00' => '02:00'}},
+        holidays: [Date.new(2006, 1, 9)]
+      )
+    )
+  }
+
+  it 'returns dates based on the configured schedule' do
+    expect(dates.after(Date.new(2006, 1, 1)).take(2).to_a).to eq [
+      Date.new(2006, 1, 2),
+      Date.new(2006, 1, 16)
+    ]
+  end
+end

--- a/spec/day_time_spec.rb
+++ b/spec/day_time_spec.rb
@@ -27,6 +27,16 @@ RSpec.describe Biz::DayTime do
     end
   end
 
+  describe '.from_time' do
+    let(:time) { Time.utc(2006, 1, 1, 9, 38) }
+
+    it 'creates a day time from the given time' do
+      expect(described_class.from_time(time).day_minute).to eq(
+        day_minute(hour: 9, min: 38)
+      )
+    end
+  end
+
   describe '.from_hour' do
     it 'creates a day time from the given hour' do
       expect(described_class.from_hour(9).day_minute).to eq day_minute(hour: 9)

--- a/spec/duration_spec.rb
+++ b/spec/duration_spec.rb
@@ -29,24 +29,6 @@ RSpec.describe Biz::Duration do
     end
   end
 
-  describe '#with_unit' do
-    context 'when called with a supported unit' do
-      it 'returns the proper duration' do
-        expect(described_class.with_unit(1, :hour)).to eq(
-          described_class.hours(1)
-        )
-      end
-    end
-
-    context 'when called with an unsupported unit' do
-      it 'fails hard' do
-        expect { described_class.with_unit(1, :parsec) }.to raise_error(
-          ArgumentError
-        )
-      end
-    end
-  end
-
   describe '.seconds' do
     it 'returns the proper duration' do
       expect(described_class.seconds(60)).to eq(

--- a/spec/holiday_spec.rb
+++ b/spec/holiday_spec.rb
@@ -56,4 +56,10 @@ RSpec.describe Biz::Holiday do
       )
     end
   end
+
+  describe '#to_date' do
+    it 'returns the appropriate date' do
+      expect(holiday.to_date).to eq Date.new(2010, 7, 15)
+    end
+  end
 end

--- a/spec/periods/after_spec.rb
+++ b/spec/periods/after_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe Biz::Periods::After do
     let(:origin) { Time.utc(2006, 1, 1) }
 
     it 'creates a timeline using its periods' do
-      expect(periods.timeline.forward.until(Time.utc(2006, 1, 4)).to_a).to eq [
+      expect(periods.timeline.until(Time.utc(2006, 1, 4)).to_a).to eq [
         Biz::TimeSegment.new(
           Time.utc(2006, 1, 2, 9),
           Time.utc(2006, 1, 2, 17)

--- a/spec/periods/after_spec.rb
+++ b/spec/periods/after_spec.rb
@@ -188,12 +188,19 @@ RSpec.describe Biz::Periods::After do
   end
 
   describe '#timeline' do
-    it 'returns a timeline' do
-      expect(periods.timeline).to be_a Biz::Timeline
-    end
+    let(:origin) { Time.utc(2006, 1, 1) }
 
-    it 'configures the timeline to use its periods' do
-      expect(periods.timeline.periods).to be periods
+    it 'creates a timeline using its periods' do
+      expect(periods.timeline.forward.until(Time.utc(2006, 1, 4)).to_a).to eq [
+        Biz::TimeSegment.new(
+          Time.utc(2006, 1, 2, 9),
+          Time.utc(2006, 1, 2, 17)
+        ),
+        Biz::TimeSegment.new(
+          Time.utc(2006, 1, 3, 10),
+          Time.utc(2006, 1, 3, 16)
+        )
+      ]
     end
   end
 end

--- a/spec/periods/before_spec.rb
+++ b/spec/periods/before_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe Biz::Periods::Before do
     let(:origin) { Time.utc(2006, 1, 4) }
 
     it 'creates a timeline using its periods' do
-      expect(periods.timeline.backward.until(Time.utc(2006, 1, 1)).to_a).to eq [
+      expect(periods.timeline.until(Time.utc(2006, 1, 1)).to_a).to eq [
         Biz::TimeSegment.new(
           Time.utc(2006, 1, 3, 10),
           Time.utc(2006, 1, 3, 16)

--- a/spec/periods/before_spec.rb
+++ b/spec/periods/before_spec.rb
@@ -186,12 +186,19 @@ RSpec.describe Biz::Periods::Before do
   end
 
   describe '#timeline' do
-    it 'returns a timeline' do
-      expect(periods.timeline).to be_a Biz::Timeline
-    end
+    let(:origin) { Time.utc(2006, 1, 4) }
 
-    it 'configures the timeline to use its periods' do
-      expect(periods.timeline.periods).to be periods
+    it 'creates a timeline using its periods' do
+      expect(periods.timeline.backward.until(Time.utc(2006, 1, 1)).to_a).to eq [
+        Biz::TimeSegment.new(
+          Time.utc(2006, 1, 3, 10),
+          Time.utc(2006, 1, 3, 16)
+        ),
+        Biz::TimeSegment.new(
+          Time.utc(2006, 1, 2, 9),
+          Time.utc(2006, 1, 2, 17)
+        )
+      ]
     end
   end
 end

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -49,8 +49,14 @@ RSpec.describe Biz::Schedule do
     end
   end
 
-    it 'configures the periods to use the schedule' do
-      expect(schedule.periods.schedule).to be schedule
+  describe '#dates' do
+    let(:hours) { {mon: {'09:00' => '17:00'}, fri: {'09:00' => '17:00'}} }
+
+    it 'returns dates for the schedule' do
+      expect(schedule.dates.after(Date.new(2006, 1, 1)).take(2).to_a).to eq [
+        Date.new(2006, 1, 2),
+        Date.new(2006, 1, 6)
+      ]
     end
   end
 

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -40,9 +40,14 @@ RSpec.describe Biz::Schedule do
   end
 
   describe '#periods' do
-    it 'returns a set of periods' do
-      expect(schedule.periods).to be_a Biz::Periods
+    let(:hours) { {mon: {'01:00' => '02:00'}} }
+
+    it 'returns periods for the schedule' do
+      expect(schedule.periods.after(Time.utc(2006, 1, 1)).first).to eq(
+        Biz::TimeSegment.new(Time.utc(2006, 1, 2, 1), Time.utc(2006, 1, 2, 2))
+      )
     end
+  end
 
     it 'configures the periods to use the schedule' do
       expect(schedule.periods.schedule).to be schedule

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -111,4 +111,14 @@ RSpec.describe Biz::Schedule do
       end
     end
   end
+
+  describe '#in_zone' do
+    let(:time_zone) { 'America/Los_Angeles' }
+
+    it 'returns a time object with its time zone' do
+      expect(schedule.in_zone.local(Time.utc(2006, 1, 1, 10))).to eq(
+        Time.utc(2006, 1, 1, 2)
+      )
+    end
+  end
 end

--- a/spec/timeline/backward_spec.rb
+++ b/spec/timeline/backward_spec.rb
@@ -1,6 +1,12 @@
 RSpec.describe Biz::Timeline::Backward do
   subject(:timeline) { described_class.new(backward_periods) }
 
+  describe '#backward' do
+    it 'returns itself' do
+      expect(timeline.backward).to eq timeline
+    end
+  end
+
   describe '#until' do
     context 'when the terminus has second precision' do
       let(:terminus) { Time.utc(2006, 1, 1, 0, 1) }

--- a/spec/timeline/forward_spec.rb
+++ b/spec/timeline/forward_spec.rb
@@ -1,6 +1,12 @@
 RSpec.describe Biz::Timeline::Forward do
   subject(:timeline) { described_class.new(forward_periods) }
 
+  describe '#forward' do
+    it 'returns itself' do
+      expect(timeline.forward).to eq timeline
+    end
+  end
+
   describe '#until' do
     context 'when the terminus has second precision' do
       let(:terminus) { Time.utc(2006, 1, 1, 0, 1) }


### PR DESCRIPTION
The impetus for this feature came from https://github.com/zendesk/biz/issues/14.

This implements day-increment calculations with a similar syntax to currently-supported units:
```ruby
Biz.time(5, :days).after(Time.now)
```

If the equivalent time in the specified number of days is in business hours, that time is returned. If that time is not in business hours, the next time in the calculation direction (e.g. `before` or `after`) will be returned.

Refer to the original issue for a more thorough discussion of the behavior and reasoning.

@alex-stone 

/cc @take