### PR TITLE
Allow second-level precision on day calculations

### DIFF
--- a/lib/biz/time.rb
+++ b/lib/biz/time.rb
@@ -33,12 +33,13 @@ module Biz
           date.month,
           date.mday,
           day_time.hour,
-          day_time.minute
+          day_time.minute,
+          day_time.second
         ),
         true
       )
     rescue TZInfo::PeriodNotFound
-      on_date(date, DayTime.new(day_time.day_minute + MINUTES_IN_HOUR))
+      on_date(date, DayTime.new(day_time.day_second + HOUR))
     end
 
     def during_week(week, week_time)

--- a/lib/biz/week_time/abstract.rb
+++ b/lib/biz/week_time/abstract.rb
@@ -35,6 +35,7 @@ module Biz
       delegate %i[
         hour
         minute
+        second
         day_minute
         timestamp
       ] => :day_time

--- a/lib/biz/week_time/end.rb
+++ b/lib/biz/week_time/end.rb
@@ -9,7 +9,7 @@ module Biz
       end
 
       def day_time
-        DayTime.new(day_of_week.day_minute(week_minute))
+        DayTime.from_minute(day_of_week.day_minute(week_minute))
       end
 
       memoize :day_of_week,

--- a/lib/biz/week_time/start.rb
+++ b/lib/biz/week_time/start.rb
@@ -11,7 +11,7 @@ module Biz
       end
 
       def day_time
-        DayTime.new(week_minute % Time::MINUTES_IN_DAY)
+        DayTime.from_minute(week_minute % Time::MINUTES_IN_DAY)
       end
 
       memoize :day_of_week,

--- a/spec/calculation/for_duration_spec.rb
+++ b/spec/calculation/for_duration_spec.rb
@@ -115,6 +115,16 @@ RSpec.describe Biz::Calculation::ForDuration do
             expect(calculation.before(time)).to eq Time.utc(2006, 1, 3, 16)
           end
         end
+
+        context 'when the time has second precision' do
+          let(:time) { Time.utc(2006, 1, 9, 12, 30, 52) }
+
+          it 'retains second precision' do
+            expect(calculation.before(time)).to eq(
+              Time.utc(2006, 1, 6, 12, 30, 52)
+            )
+          end
+        end
       end
 
       describe '#after' do
@@ -139,6 +149,16 @@ RSpec.describe Biz::Calculation::ForDuration do
 
           it 'returns the next time after the advanced time' do
             expect(calculation.after(time)).to eq Time.utc(2006, 1, 6, 9)
+          end
+        end
+
+        context 'when the time has second precision' do
+          let(:time) { Time.utc(2006, 1, 6, 12, 30, 52) }
+
+          it 'retains second precision' do
+            expect(calculation.after(time)).to eq(
+              Time.utc(2006, 1, 9, 12, 30, 52)
+            )
           end
         end
       end

--- a/spec/day_time_spec.rb
+++ b/spec/day_time_spec.rb
@@ -1,16 +1,16 @@
 RSpec.describe Biz::DayTime do
-  subject(:day_time) { described_class.new(9 * 60 + 30) }
+  subject(:day_time) { described_class.new((9 * 60 + 53) * 60 + 27) }
 
   context 'when initializing' do
     context 'with an integer' do
       it 'is successful' do
-        expect(described_class.new(1).day_minute).to eq 1
+        expect(described_class.new(1).day_second).to eq 1
       end
     end
 
     context 'with an valid integer-like value' do
       it 'is successful' do
-        expect(described_class.new('1').day_minute).to eq 1
+        expect(described_class.new('1').day_second).to eq 1
       end
     end
 
@@ -28,18 +28,26 @@ RSpec.describe Biz::DayTime do
   end
 
   describe '.from_time' do
-    let(:time) { Time.utc(2006, 1, 1, 9, 38) }
+    let(:time) { Time.utc(2006, 1, 1, 9, 38, 47) }
 
     it 'creates a day time from the given time' do
-      expect(described_class.from_time(time).day_minute).to eq(
-        day_minute(hour: 9, min: 38)
+      expect(described_class.from_time(time)).to eq(
+        day_second(hour: 9, min: 38, sec: 47)
       )
     end
   end
 
   describe '.from_hour' do
     it 'creates a day time from the given hour' do
-      expect(described_class.from_hour(9).day_minute).to eq day_minute(hour: 9)
+      expect(described_class.from_hour(9)).to eq day_second(hour: 9)
+    end
+  end
+
+  describe '.from_minute' do
+    it 'creates a day time from the given from' do
+      expect(described_class.from_minute(day_minute(hour: 9, min: 10))).to eq(
+        day_second(hour: 9, min: 10)
+      )
     end
   end
 
@@ -53,43 +61,55 @@ RSpec.describe Biz::DayTime do
     end
 
     context 'when the timestamp is well formed' do
-      let(:timestamp) { '21:43' }
+      context 'without seconds' do
+        let(:timestamp) { '21:43' }
 
-      it 'returns the appropriate day time' do
-        expect(described_class.from_timestamp(timestamp)).to eq(
-          day_minute(hour: 21, min: 43)
-        )
+        it 'returns the appropriate day time' do
+          expect(described_class.from_timestamp(timestamp)).to eq(
+            day_second(hour: 21, min: 43)
+          )
+        end
+      end
+
+      context 'with seconds' do
+        let(:timestamp) { '10:55:23' }
+
+        it 'returns the appropriate day time' do
+          expect(described_class.from_timestamp(timestamp)).to eq(
+            day_second(hour: 10, min: 55, sec: 23)
+          )
+        end
       end
     end
   end
 
   describe '.midnight' do
     it 'creates a day time that represents midnight' do
-      expect(described_class.midnight.day_minute).to eq day_minute(hour: 0)
+      expect(described_class.midnight).to eq day_second(hour: 0)
     end
   end
 
   describe '.noon' do
     it 'creates a day time that represents noon' do
-      expect(described_class.noon.day_minute).to eq day_minute(hour: 12)
+      expect(described_class.noon).to eq day_second(hour: 12)
     end
   end
 
   describe '.endnight' do
     it 'creates a day time that represents the end-of-day midnight' do
-      expect(described_class.endnight.day_minute).to eq day_minute(hour: 24)
+      expect(described_class.endnight).to eq day_second(hour: 24)
     end
   end
 
   describe '.am' do
     it 'creates a day time that represents an a.m. time (midnight)' do
-      expect(described_class.midnight.day_minute).to eq day_minute(hour: 0)
+      expect(described_class.midnight).to eq day_second(hour: 0)
     end
   end
 
   describe '.pm' do
     it 'creates a day time that represents a p.m. time (noon)' do
-      expect(described_class.noon.day_minute).to eq day_minute(hour: 12)
+      expect(described_class.noon).to eq day_second(hour: 12)
     end
   end
 
@@ -101,13 +121,25 @@ RSpec.describe Biz::DayTime do
 
   describe '#minute' do
     it 'returns the minute' do
-      expect(day_time.minute).to eq 30
+      expect(day_time.minute).to eq 53
+    end
+  end
+
+  describe '#second' do
+    it 'returns the second' do
+      expect(day_time.second).to eq 27
+    end
+  end
+
+  describe '#day_minute' do
+    it 'returns the number of minutes into the day' do
+      expect(day_time.day_minute).to eq 593
     end
   end
 
   describe '#timestamp' do
     context 'when the hour and minute are single-digit values' do
-      subject(:day_time) { described_class.new(day_minute(hour: 4, min: 3)) }
+      subject(:day_time) { described_class.new(day_second(hour: 4, min: 3)) }
 
       it 'returns a zero-padded timestamp' do
         expect(day_time.timestamp).to eq '04:03'
@@ -115,7 +147,7 @@ RSpec.describe Biz::DayTime do
     end
 
     context 'when the hour and minute are double-digit values' do
-      subject(:day_time) { described_class.new(day_minute(hour: 15, min: 27)) }
+      subject(:day_time) { described_class.new(day_second(hour: 15, min: 27)) }
 
       it 'returns a correctly formatted timestamp' do
         expect(day_time.timestamp).to eq '15:27'
@@ -125,19 +157,19 @@ RSpec.describe Biz::DayTime do
 
   describe '#strftime' do
     it 'returns a properly formatted string' do
-      expect(day_time.strftime('%H:%M %p')).to eq '09:30 AM'
+      expect(day_time.strftime('%H:%M:%S %p')).to eq '09:53:27 AM'
     end
   end
 
   describe '#to_int' do
     it 'returns the minutes since day start' do
-      expect(day_time.to_int).to eq day_minute(hour: 9, min: 30)
+      expect(day_time.to_int).to eq day_second(hour: 9, min: 53, sec: 27)
     end
   end
 
   describe '#to_i' do
     it 'returns the minutes since day start' do
-      expect(day_time.to_i).to eq day_minute(hour: 9, min: 30)
+      expect(day_time.to_i).to eq day_second(hour: 9, min: 53, sec: 27)
     end
   end
 

--- a/spec/support/time.rb
+++ b/spec/support/time.rb
@@ -41,6 +41,10 @@ module Biz
         args.fetch(:hour) * Biz::Time::MINUTES_IN_HOUR + args.fetch(:min, 0)
       end
 
+      def day_second(args = {})
+        day_minute(args) * Biz::Time::MINUTE + args.fetch(:sec, 0)
+      end
+
       def day_since_epoch(args = {})
         args.fetch(:week) * Biz::Time::DAYS_IN_WEEK + args.fetch(:wday)
       end

--- a/spec/time_spec.rb
+++ b/spec/time_spec.rb
@@ -16,18 +16,18 @@ RSpec.describe Biz::Time do
   describe '#on_date' do
     context 'when a normal time is targeted' do
       let(:date)     { Date.new(2006, 1, 4) }
-      let(:day_time) { Biz::DayTime.new(day_minute(hour: 12, min: 30)) }
+      let(:day_time) { Biz::DayTime.new(day_second(hour: 12, min: 30, sec: 9)) }
 
       it 'returns the corresponding UTC time' do
         expect(time.on_date(date, day_time)).to eq(
-          time_zone.local_to_utc(Time.utc(2006, 1, 4, 12, 30))
+          time_zone.local_to_utc(Time.utc(2006, 1, 4, 12, 30, 9))
         )
       end
     end
 
     context 'when a non-existent (spring-forward) time is targeted' do
       let(:date)     { Date.new(2014, 3, 9) }
-      let(:day_time) { Biz::DayTime.new(day_minute(hour: 2, min: 30)) }
+      let(:day_time) { Biz::DayTime.new(day_second(hour: 2, min: 30)) }
 
       it 'returns the corresponding time an hour later' do
         expect(time.on_date(date, day_time)).to eq(
@@ -38,7 +38,7 @@ RSpec.describe Biz::Time do
 
     context 'when an ambiguous time is targeted' do
       let(:date)     { Date.new(2014, 11, 2) }
-      let(:day_time) { Biz::DayTime.new(day_minute(hour: 1, min: 30)) }
+      let(:day_time) { Biz::DayTime.new(day_second(hour: 1, min: 30)) }
 
       it 'returns the DST occurrence of the time' do
         expect(time.on_date(date, day_time)).to eq(


### PR DESCRIPTION
Addresses https://github.com/zendesk/biz/issues/21 (thanks, @take!).

The underlying `DayTime` object used to power the day calculations, up to this point, did not have second-level precision as its former primary purpose was to translate timestamps (e.g. `09:50`) into actionable times.

By extending second-level precision down to this object, we bring that precision to the day calculations.

@alex-stone 