### PR TITLE
Delegate WeekTime#day_second to DayTime

### DIFF
--- a/lib/biz/week_time/abstract.rb
+++ b/lib/biz/week_time/abstract.rb
@@ -37,6 +37,7 @@ module Biz
         minute
         second
         day_minute
+        day_second
         timestamp
       ] => :day_time
 

--- a/spec/time_spec.rb
+++ b/spec/time_spec.rb
@@ -54,10 +54,36 @@ RSpec.describe Biz::Time do
       Biz::WeekTime.build(week_minute(wday: 0, hour: 1, min: 5))
     }
 
-    let(:target_time) { time_zone.local_to_utc(Time.local(2006, 1, 8, 1, 5)) }
-
     it 'returns the target time' do
-      expect(time.during_week(week, week_time)).to eq target_time
+      expect(time.during_week(week, week_time)).to eq(
+        time_zone.local_to_utc(Time.utc(2006, 1, 8, 1, 5))
+      )
+    end
+  end
+
+  context 'when a non-existent (spring-forward) time is targeted' do
+    let(:week)      { Biz::Week.new(427) }
+    let(:week_time) {
+      Biz::WeekTime.build(week_minute(wday: 0, hour: 2, min: 30))
+    }
+
+    it 'returns the target time an hour later' do
+      expect(time.during_week(week, week_time)).to eq(
+        time_zone.local_to_utc(Time.utc(2014, 3, 9, 3, 30))
+      )
+    end
+  end
+
+  context 'when an ambiguous time is targeted' do
+    let(:week)      { Biz::Week.new(461) }
+    let(:week_time) {
+      Biz::WeekTime.build(week_minute(wday: 0, hour: 1, min: 30))
+    }
+
+    it 'returns the DST occurrence of the target time' do
+      expect(time.during_week(week, week_time)).to eq(
+        time_zone.local_to_utc(Time.utc(2014, 11, 2, 1, 30), true)
+      )
     end
   end
 end

--- a/spec/week_time/end_spec.rb
+++ b/spec/week_time/end_spec.rb
@@ -63,6 +63,12 @@ RSpec.describe Biz::WeekTime::End do
     end
   end
 
+  describe '#day_second' do
+    it 'returns the corresponding day second' do
+      expect(week_time.day_second).to eq day_second(hour: 9, min: 30)
+    end
+  end
+
   describe '#hour' do
     it 'returns the corresponding hour' do
       expect(week_time.hour).to eq 9

--- a/spec/week_time/start_spec.rb
+++ b/spec/week_time/start_spec.rb
@@ -63,6 +63,12 @@ RSpec.describe Biz::WeekTime::Start do
     end
   end
 
+  describe '#day_second' do
+    it 'returns the corresponding day second' do
+      expect(week_time.day_second).to eq day_second(hour: 9, min: 30)
+    end
+  end
+
   describe '#hour' do
     it 'returns the corresponding hour' do
       expect(week_time.hour).to eq 9


### PR DESCRIPTION
When making an adjustment to a time for DST purposes, a `WeekTime` must produce its corresponding day second in order to construct a new DST-compatible time. Before, with this edge case, the calculation would simply blow up.

:bug: :hammer: 

@alex-stone 