### PR TITLE
Silence rspec `raise_error` warning

### DIFF
--- a/spec/biz_spec.rb
+++ b/spec/biz_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Biz do
     before { Thread.current[:biz_schedule] = nil }
 
     it 'fails hard' do
-      expect { described_class.intervals }.to raise_error
+      expect { described_class.intervals }.to raise_error RuntimeError
     end
   end
 end


### PR DESCRIPTION
It looks like they added this in a recent minor/patch version.

![screen shot 2015-07-29 at 2 14 01 pm](https://cloud.githubusercontent.com/assets/762635/8970133/d2c1878e-35fc-11e5-9f4c-b829a1ebcf91.png)

Begone, warning!

@alex-stone @kruppel @joshlam 