### PR TITLE
Update to latest RuboCop

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,3 @@
+engines:
+  rubocop:
+    enabled: false

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,3 +1,7 @@
 engines:
   rubocop:
     enabled: false
+
+ratings:
+  paths:
+  - '**.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,10 +43,7 @@ Style/PercentLiteralDelimiters:
     '%W': '[]'
 
 Style/SpaceAroundOperators:
-  MultiSpaceAllowedForOperators:
-    - '*'
-    - '='
-    - '||='
+  AllowForAlignment: true
 
 Style/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space

--- a/Gemfile
+++ b/Gemfile
@@ -15,5 +15,5 @@ group :test do
 end
 
 group :development, :test do
-  gem 'rubocop', '~> 0.35.0', require: false
+  gem 'rubocop', '~> 0.36.0', require: false
 end

--- a/lib/biz/calculation/duration_within.rb
+++ b/lib/biz/calculation/duration_within.rb
@@ -4,7 +4,10 @@ module Biz
 
       def initialize(schedule, calculation_period)
         super(
-          schedule.periods.after(calculation_period.start_time).timeline
+          schedule
+            .periods
+            .after(calculation_period.start_time)
+            .timeline
             .until(calculation_period.end_time)
             .map(&:duration)
             .reduce(Duration.new(0), :+)

--- a/lib/biz/configuration.rb
+++ b/lib/biz/configuration.rb
@@ -61,9 +61,10 @@ module Biz
           wed: {'09:00' => '17:00'},
           thu: {'09:00' => '17:00'},
           fri: {'09:00' => '17:00'}
-        }
-        HOLIDAYS  = []
-        TIME_ZONE = 'Etc/UTC'
+        }.freeze
+
+        HOLIDAYS  = [].freeze
+        TIME_ZONE = 'Etc/UTC'.freeze
       end
 
       def initialize(*)

--- a/lib/biz/day.rb
+++ b/lib/biz/day.rb
@@ -15,7 +15,7 @@ module Biz
 
     class << self
 
-      alias_method :since_epoch, :from_time
+      alias since_epoch from_time
 
     end
 

--- a/lib/biz/day_of_week.rb
+++ b/lib/biz/day_of_week.rb
@@ -1,7 +1,7 @@
 module Biz
   class DayOfWeek
 
-    SYMBOLS = [:sun, :mon, :tue, :wed, :thu, :fri, :sat]
+    SYMBOLS = %i[sun mon tue wed thu fri sat].freeze
 
     def self.from_time(time)
       DAYS.fetch(time.wday)
@@ -21,7 +21,7 @@ module Biz
 
     class << self
 
-      alias_method :from_date, :from_time
+      alias from_date from_time
 
     end
 
@@ -67,7 +67,7 @@ module Biz
       THURSDAY  = new(4),
       FRIDAY    = new(5),
       SATURDAY  = new(6)
-    ]
+    ].freeze
 
     WEEKDAYS = [
       MONDAY,
@@ -75,7 +75,7 @@ module Biz
       WEDNESDAY,
       THURSDAY,
       FRIDAY
-    ]
+    ].freeze
 
   end
 end

--- a/lib/biz/day_time.rb
+++ b/lib/biz/day_time.rb
@@ -4,7 +4,7 @@ module Biz
     VALID_SECONDS = 0..Time::SECONDS_IN_DAY
 
     module Timestamp
-      FORMAT  = '%02d:%02d'
+      FORMAT  = '%02d:%02d'.freeze
       PATTERN = /\A(?<hour>\d{2}):(?<minute>\d{2})(:?(?<second>\d{2}))?\Z/
     end
 
@@ -44,13 +44,13 @@ module Biz
         MIDNIGHT
       end
 
-      alias_method :am, :midnight
+      alias am midnight
 
       def noon
         NOON
       end
 
-      alias_method :pm, :noon
+      alias pm noon
 
       def endnight
         ENDNIGHT

--- a/lib/biz/duration.rb
+++ b/lib/biz/duration.rb
@@ -12,19 +12,19 @@ module Biz
         new(seconds)
       end
 
-      alias_method :second, :seconds
+      alias second seconds
 
       def minutes(minutes)
         new(minutes * Time::SECONDS_IN_MINUTE)
       end
 
-      alias_method :minute, :minutes
+      alias minute minutes
 
       def hours(hours)
         new(hours * Time::SECONDS_IN_HOUR)
       end
 
-      alias_method :hour, :hours
+      alias hour hours
 
     end
 

--- a/lib/biz/holiday.rb
+++ b/lib/biz/holiday.rb
@@ -22,7 +22,7 @@ module Biz
       )
     end
 
-    alias_method :to_date, :date
+    alias to_date date
 
   end
 end

--- a/lib/biz/schedule.rb
+++ b/lib/biz/schedule.rb
@@ -22,7 +22,7 @@ module Biz
       Dates.new(self)
     end
 
-    alias_method :date, :dates
+    alias date dates
 
     def time(scalar, unit)
       Calculation::ForDuration.with_unit(self, scalar, unit)
@@ -40,7 +40,7 @@ module Biz
       Calculation::OnHoliday.new(self, time).result
     end
 
-    alias_method :business_hours?, :in_hours?
+    alias business_hours? in_hours?
 
     def in_zone
       Time.new(time_zone)

--- a/lib/biz/validation.rb
+++ b/lib/biz/validation.rb
@@ -37,14 +37,16 @@ module Biz
 
     end
 
-    RULES = Set.new([
-      Rule.new('Hours must be hash-like.') { |raw|
-        raw.hours.respond_to?(:to_h)
-      },
-      Rule.new('Hours must be provided.') { |raw|
-        raw.hours.to_h.any?
-      }
-    ])
+    RULES = Set.new(
+      [
+        Rule.new('Hours must be hash-like.') { |raw|
+          raw.hours.respond_to?(:to_h)
+        },
+        Rule.new('Hours must be provided.') { |raw|
+          raw.hours.to_h.any?
+        }
+      ]
+    )
 
   end
 end

--- a/lib/biz/version.rb
+++ b/lib/biz/version.rb
@@ -1,3 +1,3 @@
 module Biz
-  VERSION = '1.3.3'
+  VERSION = '1.3.3'.freeze
 end

--- a/lib/biz/week.rb
+++ b/lib/biz/week.rb
@@ -15,7 +15,7 @@ module Biz
 
     class << self
 
-      alias_method :since_epoch, :from_time
+      alias since_epoch from_time
 
     end
 

--- a/lib/biz/week_time.rb
+++ b/lib/biz/week_time.rb
@@ -14,7 +14,7 @@ module Biz
         End.new(week_minute)
       end
 
-      alias_method :build, :start
+      alias build start
 
     end
   end


### PR DESCRIPTION
Changes for conformity:
  * Use `alias` instead of `alias_method` when in lexical scope
  * Freeze mutable values assigned to constants
  * Make method chaining alignment consistent
  * Use updated option for `Style/SpaceAroundOperators` cop
  * Fix alignment in multi-line array

**Reference**: [`v0.36.0` release notes](https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md#0360-1401201://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md#0360-14012016)

@alex-stone @kruppel 