### PR TITLE
Bump to latest RuboCop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,28 +1,11 @@
-AllCops:
-  Include:
-    - 'Rakefile'
-  Exclude:
-    - 'bin/**/*'
-    - 'vendor/**/*'
-
-Metrics/AbcSize:
-  Max: 25
-
-Metrics/LineLength:
-  Exclude:
-    - 'Gemfile'
-
 Metrics/MethodLength:
-  Max: 25
+  Max: 20
 
 Style/AndOr:
   EnforcedStyle: conditionals
 
 Style/BlockDelimiters:
   EnforcedStyle: semantic
-  IgnoredMethods:
-    - after
-    - before
 
 Style/Documentation:
   Enabled: false
@@ -30,20 +13,14 @@ Style/Documentation:
 Style/EmptyLinesAroundClassBody:
   EnforcedStyle: empty_lines
 
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
-Style/GuardClause:
-  MinBodyLength: 2
-
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:
     '%i': '[]'
     '%w': '[]'
     '%W': '[]'
 
-Style/SpaceAroundOperators:
-  AllowForAlignment: true
+Style/SignalException:
+  EnforcedStyle: semantic
 
 Style/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space

--- a/Gemfile
+++ b/Gemfile
@@ -15,5 +15,5 @@ group :test do
 end
 
 group :development, :test do
-  gem 'rubocop', '~> 0.36.0', require: false
+  gem 'rubocop', '~> 0.37.0', require: false
 end

--- a/biz.gemspec
+++ b/biz.gemspec
@@ -5,8 +5,8 @@ Gem::Specification.new do |gem|
   gem.version     = Biz::VERSION
   gem.authors     = ['Craig Little', 'Alex Stone']
   gem.email       = %w[clittle@zendesk.com astone@zendesk.com]
-  gem.summary     = %[Business hours calculations]
-  gem.description = %[Time calculations using business hours.]
+  gem.summary     = 'Business hours calculations'
+  gem.description = 'Time calculations using business hours.'
   gem.homepage    = 'https://github.com/zendesk/biz'
   gem.license     = 'Apache 2.0'
   gem.files       = Dir['lib/**/*', 'README.md']

--- a/spec/biz_spec.rb
+++ b/spec/biz_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe Biz do
   end
 
   context 'when not configured' do
-    before { Thread.current[:biz_schedule] = nil }
+    before do Thread.current[:biz_schedule] = nil end
 
     it 'fails hard' do
       expect { described_class.intervals }.to raise_error RuntimeError

--- a/spec/core_ext/date_spec.rb
+++ b/spec/core_ext/date_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Biz::CoreExt::Date do
     end
   end
 
-  after { Thread.current[:biz_schedule] = nil }
+  after do Thread.current[:biz_schedule] = nil end
 
   describe '#business_day?' do
     context 'when the date contains at least one business period' do

--- a/spec/core_ext/fixnum_spec.rb
+++ b/spec/core_ext/fixnum_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Biz::CoreExt::Fixnum do
     end
   end
 
-  after { Thread.current[:biz_schedule] = nil }
+  after do Thread.current[:biz_schedule] = nil end
 
   describe '#business_second' do
     it 'performs a for-duration calculation for the given number of seconds' do

--- a/spec/core_ext/time_spec.rb
+++ b/spec/core_ext/time_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Biz::CoreExt::Time do
     end
   end
 
-  after { Thread.current[:biz_schedule] = nil }
+  after do Thread.current[:biz_schedule] = nil end
 
   describe '#business_hours?' do
     context 'when the time is within a business period' do

--- a/spec/validation_spec.rb
+++ b/spec/validation_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Biz::Validation do
   subject(:validation) { described_class.new(raw) }
 
   describe '.perform' do
-    before { raw.hours = {} }
+    before do raw.hours = {} end
 
     it 'performs the validation on the provided raw input' do
       expect { described_class.perform(raw) }.to raise_error(
@@ -16,7 +16,7 @@ RSpec.describe Biz::Validation do
   describe '#perform' do
     describe 'when the hours are hash-like' do
       describe 'and the hours are not empty' do
-        before { raw.hours = {mon: {'09:00' => '17:00'}} }
+        before do raw.hours = {mon: {'09:00' => '17:00'}} end
 
         it 'does not raise an error' do
           expect { validation.perform }.not_to raise_error
@@ -24,7 +24,7 @@ RSpec.describe Biz::Validation do
       end
 
       describe 'and the hours are empty' do
-        before { raw.hours = {} }
+        before do raw.hours = {} end
 
         it 'raises a configuration error' do
           expect { validation.perform }.to raise_error Biz::Error::Configuration
@@ -33,7 +33,7 @@ RSpec.describe Biz::Validation do
     end
 
     describe 'when the hours are not hash-like' do
-      before { raw.hours = 1 }
+      before do raw.hours = 1 end
 
       it 'raises a configuration error' do
         expect { validation.perform }.to raise_error Biz::Error::Configuration


### PR DESCRIPTION
* Remove extraneous configuration
* Go all-in on semantic block delimiters
* Decrease max method length slightly
* Enforce semantic `raise`/`fail` usage (default change)

See the RuboCop changelog entry [here](https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md#0371-09022016).

@alex-stone 