### PR TITLE
Remove unwarranted gem dependencies

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,9 @@ Style/Documentation:
 Style/EmptyLinesAroundClassBody:
   EnforcedStyle: empty_lines
 
+Style/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:
     '%i': '[]'

--- a/biz.gemspec
+++ b/biz.gemspec
@@ -13,9 +13,8 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.0'
 
-  gem.add_runtime_dependency 'abstract_type', '~> 0.0.0'
-  gem.add_runtime_dependency 'clavius',       '~> 1.0'
-  gem.add_runtime_dependency 'memoizable',    '~> 0.4.0'
+  gem.add_runtime_dependency 'clavius',    '~> 1.0'
+  gem.add_runtime_dependency 'memoizable', '~> 0.4.0'
   gem.add_runtime_dependency 'tzinfo'
 
   gem.add_development_dependency 'rake',  '~> 10.0'

--- a/biz.gemspec
+++ b/biz.gemspec
@@ -13,8 +13,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.0'
 
-  gem.add_runtime_dependency 'clavius',    '~> 1.0'
-  gem.add_runtime_dependency 'memoizable', '~> 0.4.0'
+  gem.add_runtime_dependency 'clavius', '~> 1.0'
   gem.add_runtime_dependency 'tzinfo'
 
   gem.add_development_dependency 'rake',  '~> 10.0'

--- a/biz.gemspec
+++ b/biz.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'abstract_type', '~> 0.0.0'
   gem.add_runtime_dependency 'clavius',       '~> 1.0'
-  gem.add_runtime_dependency 'equalizer',     '~> 0.0.0'
   gem.add_runtime_dependency 'memoizable',    '~> 0.4.0'
   gem.add_runtime_dependency 'tzinfo'
 

--- a/lib/biz.rb
+++ b/lib/biz.rb
@@ -5,7 +5,6 @@ require 'set'
 
 require 'abstract_type'
 require 'clavius'
-require 'equalizer'
 require 'memoizable'
 require 'tzinfo'
 

--- a/lib/biz.rb
+++ b/lib/biz.rb
@@ -4,7 +4,6 @@ require 'forwardable'
 require 'set'
 
 require 'clavius'
-require 'memoizable'
 require 'tzinfo'
 
 module Biz

--- a/lib/biz.rb
+++ b/lib/biz.rb
@@ -3,7 +3,6 @@ require 'delegate'
 require 'forwardable'
 require 'set'
 
-require 'abstract_type'
 require 'clavius'
 require 'memoizable'
 require 'tzinfo'

--- a/lib/biz/calculation/for_duration.rb
+++ b/lib/biz/calculation/for_duration.rb
@@ -4,8 +4,6 @@ module Biz
 
       UNITS = Set.new(%i[second seconds minute minutes hour hours day days])
 
-      include AbstractType
-
       def self.with_unit(schedule, scalar, unit)
         unless UNITS.include?(unit)
           fail ArgumentError, 'The unit is not supported.'
@@ -22,9 +20,6 @@ module Biz
         @schedule = schedule
         @scalar   = scalar
       end
-
-      abstract_method :before,
-                      :after
 
       protected
 

--- a/lib/biz/duration.rb
+++ b/lib/biz/duration.rb
@@ -1,7 +1,6 @@
 module Biz
   class Duration
 
-    include Equalizer.new(:seconds)
     include Comparable
 
     extend Forwardable

--- a/lib/biz/holiday.rb
+++ b/lib/biz/holiday.rb
@@ -1,8 +1,6 @@
 module Biz
   class Holiday
 
-    include Equalizer.new(:date, :time_zone)
-
     attr_reader :date,
                 :time_zone
 

--- a/lib/biz/interval.rb
+++ b/lib/biz/interval.rb
@@ -1,8 +1,6 @@
 module Biz
   class Interval
 
-    include Equalizer.new(:start_time, :end_time, :time_zone)
-
     attr_reader :start_time,
                 :end_time,
                 :time_zone

--- a/lib/biz/time_segment.rb
+++ b/lib/biz/time_segment.rb
@@ -1,8 +1,6 @@
 module Biz
   class TimeSegment
 
-    include Equalizer.new(:start_time, :end_time)
-
     def self.before(time)
       new(Time::BIG_BANG, time)
     end

--- a/lib/biz/week_time/abstract.rb
+++ b/lib/biz/week_time/abstract.rb
@@ -2,7 +2,6 @@ module Biz
   module WeekTime
     class Abstract
 
-      include AbstractType
       include Comparable
       include Memoizable
 
@@ -49,8 +48,6 @@ module Biz
         to_int
       ] => :week_minute
 
-      abstract_method :day_time
-
       protected
 
       def <=>(other)
@@ -70,8 +67,6 @@ module Biz
           minute
         )
       end
-
-      abstract_method :day_of_week
 
     end
   end

--- a/lib/biz/week_time/abstract.rb
+++ b/lib/biz/week_time/abstract.rb
@@ -3,7 +3,6 @@ module Biz
     class Abstract
 
       include Comparable
-      include Memoizable
 
       extend Forwardable
 

--- a/lib/biz/week_time/end.rb
+++ b/lib/biz/week_time/end.rb
@@ -3,17 +3,16 @@ module Biz
     class End < Abstract
 
       def day_time
-        DayTime.from_minute(day_of_week.day_minute(week_minute))
+        @day_time ||= DayTime.from_minute(day_of_week.day_minute(week_minute))
       end
 
       private
 
       def day_of_week
-        DayOfWeek::DAYS.find { |day| day.contains?(week_minute) }
+        @day_of_week ||= begin
+          DayOfWeek::DAYS.find { |day| day.contains?(week_minute) }
+        end
       end
-
-      memoize :day_of_week,
-              :day_time
 
     end
   end

--- a/lib/biz/week_time/start.rb
+++ b/lib/biz/week_time/start.rb
@@ -3,19 +3,18 @@ module Biz
     class Start < Abstract
 
       def day_time
-        DayTime.from_minute(week_minute % Time::MINUTES_IN_DAY)
+        @day_time ||= DayTime.from_minute(week_minute % Time::MINUTES_IN_DAY)
       end
 
       private
 
       def day_of_week
-        DayOfWeek::DAYS.fetch(
-          week_minute / Time::MINUTES_IN_DAY % Time::DAYS_IN_WEEK
-        )
+        @day_of_week ||= begin
+          DayOfWeek::DAYS.fetch(
+            week_minute / Time::MINUTES_IN_DAY % Time::DAYS_IN_WEEK
+          )
+        end
       end
-
-      memoize :day_of_week,
-              :day_time
 
     end
   end

--- a/spec/biz_spec.rb
+++ b/spec/biz_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Biz do
 
     describe '.intervals' do
       it 'delegates to the top-level schedule' do
-        expect(described_class.intervals).to eq(
+        expect(described_class.intervals).to eq_intervals(
           [
             Biz::Interval.new(
               Biz::WeekTime.start(week_minute(wday: 0, hour: 11)),
@@ -24,7 +24,7 @@ RSpec.describe Biz do
 
     describe '.holidays' do
       it 'delegates to the top-level schedule' do
-        expect(described_class.holidays).to eq(
+        expect(described_class.holidays).to eq_holidays(
           [
             Biz::Holiday.new(
               Date.new(2015, 12, 25),
@@ -45,7 +45,9 @@ RSpec.describe Biz do
 
     describe '.periods' do
       it 'delegates to the top-level schedule' do
-        expect(described_class.periods.after(Time.utc(2006, 1, 1)).first).to eq(
+        expect(
+          described_class.periods.after(Time.utc(2006, 1, 1)).first
+        ).to eq_time_segment(
           Biz::TimeSegment.new(
             Time.utc(2006, 1, 1, 11),
             Time.utc(2006, 1, 1, 12)

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Biz::Configuration do
       }
 
       it 'returns the default set of intervals' do
-        expect(configuration.intervals).to eq(
+        expect(configuration.intervals).to eq_intervals(
           Biz::DayOfWeek::WEEKDAYS.map { |weekday|
             Biz::Interval.new(
               Biz::WeekTime.start(week_minute(wday: weekday.wday, hour: 9)),
@@ -71,7 +71,7 @@ RSpec.describe Biz::Configuration do
     end
 
     it 'returns the proper intervals' do
-      expect(configuration.intervals).to eq [
+      expect(configuration.intervals).to eq_intervals [
         Biz::Interval.new(
           Biz::WeekTime.start(week_minute(wday: 1, hour: 9)),
           Biz::WeekTime.end(week_minute(wday: 1, hour: 17)),
@@ -109,7 +109,7 @@ RSpec.describe Biz::Configuration do
       let(:hours) { {mon: {'09:00' => '17:00'}, tue: {'10:00' => '16:00'}} }
 
       it 'returns the intervals in order' do
-        expect(configuration.intervals).to eq [
+        expect(configuration.intervals).to eq_intervals [
           Biz::Interval.new(
             Biz::WeekTime.start(week_minute(wday: 1, hour: 9)),
             Biz::WeekTime.end(week_minute(wday: 1, hour: 17)),
@@ -140,7 +140,7 @@ RSpec.describe Biz::Configuration do
     end
 
     it 'returns the proper holidays' do
-      expect(configuration.holidays).to eq [
+      expect(configuration.holidays).to eq_holidays [
         Biz::Holiday.new(
           Date.new(2006, 1, 1),
           TZInfo::Timezone.get('America/New_York')

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -14,4 +14,4 @@ RSpec.configure do |config|
   config.disable_monkey_patching!
 end
 
-require 'support/time'
+require 'support'

--- a/spec/holiday_spec.rb
+++ b/spec/holiday_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Biz::Holiday do
 
   describe '#to_time_segment' do
     it 'returns the appropriate time segment' do
-      expect(holiday.to_time_segment).to eq(
+      expect(holiday.to_time_segment).to eq_time_segment(
         Biz::TimeSegment.new(
           in_zone('America/Los_Angeles') { Time.utc(2010, 7, 15) },
           in_zone('America/Los_Angeles') { Time.utc(2010, 7, 16) }

--- a/spec/interval_spec.rb
+++ b/spec/interval_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Biz::Interval do
     let(:week) { Biz::Week.new(4) }
 
     it 'returns the appropriate time segment for the given week' do
-      expect(interval.to_time_segment(week)).to eq(
+      expect(interval.to_time_segment(week)).to eq_time_segment(
         Biz::TimeSegment.new(
           in_zone('America/Los_Angeles') { Time.utc(2006, 1, 30, 9) },
           in_zone('America/Los_Angeles') { Time.utc(2006, 1, 30, 17) }
@@ -74,7 +74,7 @@ RSpec.describe Biz::Interval do
       }
 
       it 'returns the appropriate time segment' do
-        expect(interval.to_time_segment(week)).to eq(
+        expect(interval.to_time_segment(week)).to eq_time_segment(
           Biz::TimeSegment.new(
             in_zone('America/Los_Angeles') { Time.utc(2006, 1, 30) },
             in_zone('America/Los_Angeles') { Time.utc(2006, 1, 31) }
@@ -88,7 +88,7 @@ RSpec.describe Biz::Interval do
       let(:end_time)   { Biz::WeekTime.end(Biz::Time::MINUTES_IN_WEEK) }
 
       it 'returns the appropriate time segment' do
-        expect(interval.to_time_segment(week)).to eq(
+        expect(interval.to_time_segment(week)).to eq_time_segment(
           Biz::TimeSegment.new(
             in_zone('America/Los_Angeles') { Time.utc(2006, 1, 29) },
             in_zone('America/Los_Angeles') { Time.utc(2006, 2, 5) }

--- a/spec/periods/after_spec.rb
+++ b/spec/periods/after_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Biz::Periods::After do
     let(:origin) { Time.utc(2006, 1, 1) }
 
     it 'returns the proper intervals' do
-      expect(periods.take(6).to_a).to eq [
+      expect(periods.take(6).to_a).to eq_time_segments [
         Biz::TimeSegment.new(
           Time.utc(2006, 1, 2, 9),
           Time.utc(2006, 1, 2, 17)
@@ -58,7 +58,7 @@ RSpec.describe Biz::Periods::After do
     let(:origin) { Time.utc(2006, 1, 1) }
 
     it 'returns the proper intervals' do
-      expect(periods.take(12).to_a).to eq [
+      expect(periods.take(12).to_a).to eq_time_segments [
         Biz::TimeSegment.new(
           Time.utc(2006, 1, 2, 9),
           Time.utc(2006, 1, 2, 17)
@@ -115,7 +115,7 @@ RSpec.describe Biz::Periods::After do
     let(:origin) { Time.utc(2006, 1, 1) }
 
     it 'returns a full period first' do
-      expect(periods.first).to eq(
+      expect(periods.first).to eq_time_segment(
         Biz::TimeSegment.new(Time.utc(2006, 1, 2, 9), Time.utc(2006, 1, 2, 17))
       )
     end
@@ -125,7 +125,7 @@ RSpec.describe Biz::Periods::After do
     let(:origin) { Time.utc(2006, 1, 2, 12) }
 
     it 'returns a partial period first' do
-      expect(periods.first).to eq(
+      expect(periods.first).to eq_time_segment(
         Biz::TimeSegment.new(Time.utc(2006, 1, 2, 12), Time.utc(2006, 1, 2, 17))
       )
     end
@@ -135,7 +135,7 @@ RSpec.describe Biz::Periods::After do
     let(:origin) { Time.utc(2006, 1, 14) }
 
     it 'does not include that period' do
-      expect(periods.take(2).to_a).to eq [
+      expect(periods.take(2).to_a).to eq_time_segments [
         Biz::TimeSegment.new(
           Time.utc(2006, 1, 14, 11),
           Time.utc(2006, 1, 14, 14, 30)
@@ -152,7 +152,7 @@ RSpec.describe Biz::Periods::After do
     let(:origin) { Time.utc(2006, 1, 14) }
 
     it 'does not include any of those periods' do
-      expect(periods.take(3).to_a).to eq [
+      expect(periods.take(3).to_a).to eq_time_segments [
         Biz::TimeSegment.new(
           Time.utc(2006, 1, 14, 11),
           Time.utc(2006, 1, 14, 14, 30)
@@ -178,7 +178,7 @@ RSpec.describe Biz::Periods::After do
     }
 
     it 'includes the relevant interval from the prior week' do
-      expect(periods.first).to eq(
+      expect(periods.first).to eq_time_segment(
         Biz::TimeSegment.new(
           in_zone('America/Los_Angeles') { Time.utc(2006, 1, 7, 17) },
           in_zone('America/Los_Angeles') { Time.utc(2006, 1, 7, 18) }
@@ -191,7 +191,9 @@ RSpec.describe Biz::Periods::After do
     let(:origin) { Time.utc(2006, 1, 1) }
 
     it 'creates a timeline using its periods' do
-      expect(periods.timeline.until(Time.utc(2006, 1, 4)).to_a).to eq [
+      expect(
+        periods.timeline.until(Time.utc(2006, 1, 4)).to_a
+      ).to eq_time_segments [
         Biz::TimeSegment.new(
           Time.utc(2006, 1, 2, 9),
           Time.utc(2006, 1, 2, 17)

--- a/spec/periods/before_spec.rb
+++ b/spec/periods/before_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Biz::Periods::Before do
     let(:origin) { Time.utc(2006, 1, 8) }
 
     it 'returns the proper intervals' do
-      expect(periods.take(6).to_a).to eq [
+      expect(periods.take(6).to_a).to eq_time_segments [
         Biz::TimeSegment.new(
           Time.utc(2006, 1, 7, 11),
           Time.utc(2006, 1, 7, 14, 30)
@@ -58,7 +58,7 @@ RSpec.describe Biz::Periods::Before do
     let(:origin) { Time.utc(2006, 1, 15) }
 
     it 'returns the proper intervals' do
-      expect(periods.take(12).to_a).to eq [
+      expect(periods.take(12).to_a).to eq_time_segments [
         Biz::TimeSegment.new(
           Time.utc(2006, 1, 14, 11),
           Time.utc(2006, 1, 14, 14, 30)
@@ -115,7 +115,7 @@ RSpec.describe Biz::Periods::Before do
     let(:origin) { Time.utc(2006, 1, 3) }
 
     it 'returns a full period first' do
-      expect(periods.first).to eq(
+      expect(periods.first).to eq_time_segment(
         Biz::TimeSegment.new(Time.utc(2006, 1, 2, 9), Time.utc(2006, 1, 2, 17))
       )
     end
@@ -125,7 +125,7 @@ RSpec.describe Biz::Periods::Before do
     let(:origin) { Time.utc(2006, 1, 2, 12) }
 
     it 'returns a partial period first' do
-      expect(periods.first).to eq(
+      expect(periods.first).to eq_time_segment(
         Biz::TimeSegment.new(Time.utc(2006, 1, 2, 9), Time.utc(2006, 1, 2, 12))
       )
     end
@@ -135,7 +135,7 @@ RSpec.describe Biz::Periods::Before do
     let(:origin) { Time.utc(2006, 1, 18) }
 
     it 'does not include that period' do
-      expect(periods.take(2).to_a).to eq [
+      expect(periods.take(2).to_a).to eq_time_segments [
         Biz::TimeSegment.new(
           Time.utc(2006, 1, 17, 10),
           Time.utc(2006, 1, 17, 16)
@@ -152,7 +152,7 @@ RSpec.describe Biz::Periods::Before do
     let(:origin) { Time.utc(2006, 1, 20) }
 
     it 'does not include any of those periods' do
-      expect(periods.take(3).to_a).to eq [
+      expect(periods.take(3).to_a).to eq_time_segments [
         Biz::TimeSegment.new(
           Time.utc(2006, 1, 19, 10),
           Time.utc(2006, 1, 19, 16)
@@ -176,7 +176,7 @@ RSpec.describe Biz::Periods::Before do
     let(:origin) { in_zone('Asia/Brunei') { Time.utc(2006, 1, 8, 7) } }
 
     it 'includes the relevant interval from the prior week' do
-      expect(periods.first).to eq(
+      expect(periods.first).to eq_time_segment(
         Biz::TimeSegment.new(
           in_zone('Asia/Brunei') { Time.utc(2006, 1, 8, 6) },
           in_zone('Asia/Brunei') { Time.utc(2006, 1, 8, 7) }
@@ -189,7 +189,9 @@ RSpec.describe Biz::Periods::Before do
     let(:origin) { Time.utc(2006, 1, 4) }
 
     it 'creates a timeline using its periods' do
-      expect(periods.timeline.until(Time.utc(2006, 1, 1)).to_a).to eq [
+      expect(
+        periods.timeline.until(Time.utc(2006, 1, 1)).to_a
+      ).to eq_time_segments [
         Biz::TimeSegment.new(
           Time.utc(2006, 1, 3, 10),
           Time.utc(2006, 1, 3, 16)

--- a/spec/periods/proxy_spec.rb
+++ b/spec/periods/proxy_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Biz::Periods::Proxy do
     let(:origin) { Time.utc(2006, 1, 3) }
 
     it 'generates periods after the provided origin' do
-      expect(periods.after(origin).take(2).to_a).to eq [
+      expect(periods.after(origin).take(2).to_a).to eq_time_segments [
         Biz::TimeSegment.new(
           Time.utc(2006, 1, 3, 10),
           Time.utc(2006, 1, 3, 16)
@@ -22,7 +22,7 @@ RSpec.describe Biz::Periods::Proxy do
     let(:origin) { Time.utc(2006, 1, 5) }
 
     it 'generates periods before the provided origin' do
-      expect(periods.before(origin).take(2).to_a).to eq [
+      expect(periods.before(origin).take(2).to_a).to eq_time_segments [
         Biz::TimeSegment.new(
           Time.utc(2006, 1, 4, 9),
           Time.utc(2006, 1, 4, 17)

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -23,13 +23,17 @@ RSpec.describe Biz::Schedule do
 
   describe '#intervals' do
     it 'delegates to the configuration' do
-      expect(schedule.intervals).to eq Biz::Configuration.new(&config).intervals
+      expect(schedule.intervals).to eq_intervals(
+        Biz::Configuration.new(&config).intervals
+      )
     end
   end
 
   describe '#holidays' do
     it 'delegates to the configuration' do
-      expect(schedule.holidays).to eq Biz::Configuration.new(&config).holidays
+      expect(schedule.holidays).to eq_holidays(
+        Biz::Configuration.new(&config).holidays
+      )
     end
   end
 
@@ -43,7 +47,9 @@ RSpec.describe Biz::Schedule do
     let(:hours) { {mon: {'01:00' => '02:00'}} }
 
     it 'returns periods for the schedule' do
-      expect(schedule.periods.after(Time.utc(2006, 1, 1)).first).to eq(
+      expect(
+        schedule.periods.after(Time.utc(2006, 1, 1)).first
+      ).to eq_time_segment(
         Biz::TimeSegment.new(Time.utc(2006, 1, 2, 1), Time.utc(2006, 1, 2, 2))
       )
     end

--- a/spec/support.rb
+++ b/spec/support.rb
@@ -1,0 +1,2 @@
+require 'support/matchers'
+require 'support/time'

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -1,0 +1,4 @@
+require 'support/matchers/eq_holidays'
+require 'support/matchers/eq_intervals'
+require 'support/matchers/eq_time_segment'
+require 'support/matchers/eq_time_segments'

--- a/spec/support/matchers/eq_holidays.rb
+++ b/spec/support/matchers/eq_holidays.rb
@@ -1,0 +1,26 @@
+RSpec::Matchers.define :eq_holidays do |expected|
+  match do |actual|
+    holidays?(expected) && holidays?(actual) && equivalent?(expected, actual)
+  end
+
+  failure_message do |actual|
+    "expected holidays: #{expected}\n" \
+    "     got holidays: #{actual}"
+  end
+
+  diffable
+
+  def holidays?(holidays)
+    holidays.all? { |holiday| holiday.is_a?(Biz::Holiday) }
+  end
+
+  def equivalent?(expected, actual)
+    raw_holidays(expected) == raw_holidays(actual)
+  end
+
+  def raw_holidays(holidays)
+    holidays.map { |holiday|
+      {date: holiday.date, time_zone: holiday.time_zone}
+    }
+  end
+end

--- a/spec/support/matchers/eq_intervals.rb
+++ b/spec/support/matchers/eq_intervals.rb
@@ -1,0 +1,30 @@
+RSpec::Matchers.define :eq_intervals do |expected|
+  match do |actual|
+    intervals?(expected) && intervals?(actual) && equivalent?(expected, actual)
+  end
+
+  failure_message do |actual|
+    "expected intervals: #{expected}\n" \
+    "     got intervals: #{actual}"
+  end
+
+  diffable
+
+  def intervals?(intervals)
+    intervals.all? { |interval| interval.is_a?(Biz::Interval) }
+  end
+
+  def equivalent?(expected, actual)
+    raw_intervals(expected) == raw_intervals(actual)
+  end
+
+  def raw_intervals(intervals)
+    intervals.map { |interval|
+      {
+        start_time: interval.start_time,
+        end_time:   interval.end_time,
+        time_zone:  interval.time_zone
+      }
+    }
+  end
+end

--- a/spec/support/matchers/eq_time_segment.rb
+++ b/spec/support/matchers/eq_time_segment.rb
@@ -1,0 +1,26 @@
+RSpec::Matchers.define :eq_time_segment do |expected|
+  match do |actual|
+    time_segment?(expected) &&
+      time_segment?(actual) &&
+      equivalent?(expected, actual)
+  end
+
+  failure_message do |actual|
+    "expected time segment: #{expected}\n" \
+    "     got time segment: #{actual}"
+  end
+
+  diffable
+
+  def time_segment?(time_segment)
+    time_segment.is_a?(Biz::TimeSegment)
+  end
+
+  def equivalent?(expected, actual)
+    raw_time_segment(expected) == raw_time_segment(actual)
+  end
+
+  def raw_time_segment(time_segment)
+    {start_time: time_segment.start_time, end_time: time_segment.end_time}
+  end
+end

--- a/spec/support/matchers/eq_time_segments.rb
+++ b/spec/support/matchers/eq_time_segments.rb
@@ -1,0 +1,28 @@
+RSpec::Matchers.define :eq_time_segments do |expected|
+  match do |actual|
+    time_segments?(expected) &&
+      time_segments?(actual) &&
+      equivalent?(expected, actual)
+  end
+
+  failure_message do |actual|
+    "expected time segments: #{expected}\n" \
+    "     got time segments: #{actual}"
+  end
+
+  diffable
+
+  def time_segments?(time_segments)
+    time_segments.all? { |time_segment| time_segment.is_a?(Biz::TimeSegment) }
+  end
+
+  def equivalent?(expected, actual)
+    raw_time_segments(expected) == raw_time_segments(actual)
+  end
+
+  def raw_time_segments(time_segments)
+    time_segments.map { |time_segment|
+      {start_time: time_segment.start_time, end_time: time_segment.end_time}
+    }
+  end
+end

--- a/spec/support/time.rb
+++ b/spec/support/time.rb
@@ -1,94 +1,65 @@
 module Biz
-  module SpecSupport
-    module Time
-      def in_zone(zone)
-        TZInfo::Timezone.get(zone).local_to_utc(yield)
-      end
-
-      def raw_interval(args = {})
-        args.merge(
-          start_time: week_minute(args.fetch(:start_time)),
-          end_time:   week_minute(args.fetch(:end_time))
-        )
-      end
-
-      def raw_holiday(args = {})
-        if args.is_a?(Hash)
-          start_date = args.fetch(:start_date) { args.delete(:date) }
-          end_date   = args.fetch(:end_date) { start_date }
-          name       = args.fetch(:name, 'Test Holiday')
-          raw_args   = args
-        else
-          start_date = args
-          end_date   = args
-          name       = 'Test Holiday'
-          raw_args   = {}
+  module Spec
+    module Support
+      module Time
+        def in_zone(zone)
+          TZInfo::Timezone.get(zone).local_to_utc(yield)
         end
 
-        raw_args.merge(
-          name:       name,
-          start_date: Day.since_epoch(start_date),
-          end_date:   Day.since_epoch(end_date)
-        )
-      end
-
-      def week_minute(args = {})
-        args.fetch(:wday) * Biz::Time::MINUTES_IN_DAY + day_minute(args)
-      end
-
-      def day_minute(args = {})
-        args.fetch(:hour) * Biz::Time::MINUTES_IN_HOUR + args.fetch(:min, 0)
-      end
-
-      def day_second(args = {})
-        day_minute(args) * Biz::Time::SECONDS_IN_MINUTE + args.fetch(:sec, 0)
-      end
-
-      def day_since_epoch(args = {})
-        args.fetch(:week) * Biz::Time::DAYS_IN_WEEK + args.fetch(:wday)
-      end
-
-      def in_seconds(args = {})
-        args.fetch(:days, 0) * Biz::Time::SECONDS_IN_DAY +
-          args.fetch(:hours, 0) * Biz::Time::SECONDS_IN_HOUR +
-          args.fetch(:minutes, 0) * Biz::Time::SECONDS_IN_MINUTE +
-          args.fetch(:seconds, 0)
-      end
-
-      def schedule(args = {})
-        Biz::Schedule.new do |config|
-          config.hours = args.fetch(
-            :hours,
-            mon: {'09:00' => '17:00'},
-            tue: {'10:00' => '16:00'},
-            wed: {'09:00' => '17:00'},
-            thu: {'10:00' => '16:00'},
-            fri: {'09:00' => '17:00'},
-            sat: {'11:00' => '14:30'}
-          )
-
-          config.holidays = args.fetch(:holidays, [])
-
-          config.time_zone = args.fetch(:time_zone, 'Etc/UTC')
+        def week_minute(args = {})
+          args.fetch(:wday) * Biz::Time::MINUTES_IN_DAY + day_minute(args)
         end
-      end
 
-      def forward_periods
-        Enumerator.new do |yielder|
-          (2006..Float::INFINITY).each do |year|
-            yielder.yield(
-              Biz::TimeSegment.new(::Time.utc(year), ::Time.utc(year, 2))
+        def day_minute(args = {})
+          args.fetch(:hour) * Biz::Time::MINUTES_IN_HOUR + args.fetch(:min, 0)
+        end
+
+        def day_second(args = {})
+          day_minute(args) * Biz::Time::SECONDS_IN_MINUTE + args.fetch(:sec, 0)
+        end
+
+        def in_seconds(args = {})
+          args.fetch(:days, 0) * Biz::Time::SECONDS_IN_DAY +
+            args.fetch(:hours, 0) * Biz::Time::SECONDS_IN_HOUR +
+            args.fetch(:minutes, 0) * Biz::Time::SECONDS_IN_MINUTE +
+            args.fetch(:seconds, 0)
+        end
+
+        def schedule(args = {})
+          Biz::Schedule.new do |config|
+            config.hours = args.fetch(
+              :hours,
+              mon: {'09:00' => '17:00'},
+              tue: {'10:00' => '16:00'},
+              wed: {'09:00' => '17:00'},
+              thu: {'10:00' => '16:00'},
+              fri: {'09:00' => '17:00'},
+              sat: {'11:00' => '14:30'}
             )
+
+            config.holidays = args.fetch(:holidays, [])
+
+            config.time_zone = args.fetch(:time_zone, 'Etc/UTC')
           end
         end
-      end
 
-      def backward_periods
-        Enumerator.new do |yielder|
-          2006.downto(-Float::INFINITY).each do |year|
-            yielder.yield(
-              Biz::TimeSegment.new(::Time.utc(year), ::Time.utc(year, 2))
-            )
+        def forward_periods
+          Enumerator.new do |yielder|
+            (2006..Float::INFINITY).each do |year|
+              yielder.yield(
+                Biz::TimeSegment.new(::Time.utc(year), ::Time.utc(year, 2))
+              )
+            end
+          end
+        end
+
+        def backward_periods
+          Enumerator.new do |yielder|
+            2006.downto(-Float::INFINITY).each do |year|
+              yielder.yield(
+                Biz::TimeSegment.new(::Time.utc(year), ::Time.utc(year, 2))
+              )
+            end
           end
         end
       end
@@ -96,4 +67,4 @@ module Biz
   end
 end
 
-RSpec.configure do |c| c.include Biz::SpecSupport::Time end
+RSpec.configure do |c| c.include Biz::Spec::Support::Time end

--- a/spec/time_segment_spec.rb
+++ b/spec/time_segment_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Biz::TimeSegment do
 
   describe '.before' do
     it 'returns the time segment before the provided time' do
-      expect(described_class.before(start_time)).to eq(
+      expect(described_class.before(start_time)).to eq_time_segment(
         described_class.new(Biz::Time::BIG_BANG, start_time)
       )
     end
@@ -14,7 +14,7 @@ RSpec.describe Biz::TimeSegment do
 
   describe '.after' do
     it 'returns the time segment after the provided time' do
-      expect(described_class.after(start_time)).to eq(
+      expect(described_class.after(start_time)).to eq_time_segment(
         described_class.new(start_time, Biz::Time::HEAT_DEATH)
       )
     end
@@ -103,7 +103,7 @@ RSpec.describe Biz::TimeSegment do
       let(:other_end_time)   { Time.utc(2006, 1, 2) }
 
       it 'returns a zero-duration time segment' do
-        expect(time_segment & other).to eq(
+        expect(time_segment & other).to eq_time_segment(
           described_class.new(start_time, start_time)
         )
       end
@@ -116,7 +116,7 @@ RSpec.describe Biz::TimeSegment do
         let(:other_end_time) { Time.utc(2006, 1, 8, 11, 45) }
 
         it 'returns the correct time segment' do
-          expect(time_segment & other).to eq(
+          expect(time_segment & other).to eq_time_segment(
             described_class.new(start_time, other_end_time)
           )
         end
@@ -126,7 +126,7 @@ RSpec.describe Biz::TimeSegment do
         let(:other_end_time) { Time.utc(2006, 1, 23) }
 
         it 'returns the correct time segment' do
-          expect(time_segment & other).to eq(
+          expect(time_segment & other).to eq_time_segment(
             described_class.new(start_time, end_time)
           )
         end
@@ -140,7 +140,7 @@ RSpec.describe Biz::TimeSegment do
         let(:other_end_time) { Time.utc(2006, 1, 9, 12, 30) }
 
         it 'returns the correct time segment' do
-          expect(time_segment & other).to eq(
+          expect(time_segment & other).to eq_time_segment(
             described_class.new(other_start_time, other_end_time)
           )
         end
@@ -150,7 +150,7 @@ RSpec.describe Biz::TimeSegment do
         let(:other_end_time) { Time.utc(2006, 1, 23) }
 
         it 'returns the correct time segment' do
-          expect(time_segment & other).to eq(
+          expect(time_segment & other).to eq_time_segment(
             described_class.new(other_start_time, end_time)
           )
         end
@@ -162,7 +162,7 @@ RSpec.describe Biz::TimeSegment do
       let(:other_end_time)   { Time.utc(2006, 2, 7) }
 
       it 'returns a zero-duration time segment' do
-        expect(time_segment & other).to eq(
+        expect(time_segment & other).to eq_time_segment(
           described_class.new(other_start_time, other_start_time)
         )
       end
@@ -177,7 +177,7 @@ RSpec.describe Biz::TimeSegment do
       let(:other_end_time)   { Time.utc(2006, 1, 2) }
 
       it 'returns the original time segment' do
-        expect(time_segment / other).to eq [time_segment]
+        expect(time_segment / other).to eq_time_segments [time_segment]
       end
     end
 
@@ -188,9 +188,9 @@ RSpec.describe Biz::TimeSegment do
         let(:other_end_time) { Time.utc(2006, 1, 8, 11, 45) }
 
         it 'returns the correct time segment' do
-          expect(time_segment / other).to eq(
-            [described_class.new(other.end_time, time_segment.end_time)]
-          )
+          expect(time_segment / other).to eq_time_segments [
+            described_class.new(other.end_time, time_segment.end_time)
+          ]
         end
       end
 
@@ -210,7 +210,7 @@ RSpec.describe Biz::TimeSegment do
         let(:other_end_time) { Time.utc(2006, 1, 9, 12, 30) }
 
         it 'returns the correct time segments' do
-          expect(time_segment / other).to eq [
+          expect(time_segment / other).to eq_time_segments [
             described_class.new(time_segment.start_time, other.start_time),
             described_class.new(other.end_time, time_segment.end_time)
           ]
@@ -221,9 +221,9 @@ RSpec.describe Biz::TimeSegment do
         let(:other_end_time) { Time.utc(2006, 1, 23) }
 
         it 'returns the correct time segment' do
-          expect(time_segment / other).to eq(
-            [described_class.new(time_segment.start_time, other.start_time)]
-          )
+          expect(time_segment / other).to eq_time_segments [
+            described_class.new(time_segment.start_time, other.start_time)
+          ]
         end
       end
     end
@@ -233,7 +233,7 @@ RSpec.describe Biz::TimeSegment do
       let(:other_end_time)   { Time.utc(2006, 2, 7) }
 
       it 'returns the original time segment' do
-        expect(time_segment / other).to eq [time_segment]
+        expect(time_segment / other).to eq_time_segments [time_segment]
       end
     end
   end

--- a/spec/timeline/backward_spec.rb
+++ b/spec/timeline/backward_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Biz::Timeline::Backward do
       let(:terminus) { Time.utc(2006, 1, 1, 0, 1) }
 
       it 'returns a period with second precision' do
-        expect(timeline.until(terminus).to_a).to eq [
+        expect(timeline.until(terminus).to_a).to eq_time_segments [
           Biz::TimeSegment.new(Time.utc(2006, 1, 1, 0, 1), Time.utc(2006, 2))
         ]
       end
@@ -30,7 +30,7 @@ RSpec.describe Biz::Timeline::Backward do
       let(:terminus) { Time.utc(2004, 3) }
 
       it 'returns the proper periods' do
-        expect(timeline.until(terminus).to_a).to eq [
+        expect(timeline.until(terminus).to_a).to eq_time_segments [
           Biz::TimeSegment.new(Time.utc(2006), Time.utc(2006, 2)),
           Biz::TimeSegment.new(Time.utc(2005), Time.utc(2005, 2))
         ]
@@ -41,7 +41,7 @@ RSpec.describe Biz::Timeline::Backward do
       let(:terminus) { Time.utc(2004, 2) }
 
       it 'returns the proper periods' do
-        expect(timeline.until(terminus).to_a).to eq [
+        expect(timeline.until(terminus).to_a).to eq_time_segments [
           Biz::TimeSegment.new(Time.utc(2006), Time.utc(2006, 2)),
           Biz::TimeSegment.new(Time.utc(2005), Time.utc(2005, 2))
         ]
@@ -60,7 +60,7 @@ RSpec.describe Biz::Timeline::Backward do
       let(:terminus) { Time.utc(2005, 1, 15) }
 
       it 'returns the proper periods' do
-        expect(timeline.until(terminus).to_a).to eq [
+        expect(timeline.until(terminus).to_a).to eq_time_segments [
           Biz::TimeSegment.new(Time.utc(2006), Time.utc(2006, 2)),
           Biz::TimeSegment.new(Time.utc(2005, 1, 15), Time.utc(2005, 2))
         ]
@@ -71,7 +71,7 @@ RSpec.describe Biz::Timeline::Backward do
       let(:terminus) { Time.utc(2005) }
 
       it 'returns the proper periods' do
-        expect(timeline.until(terminus).to_a).to eq [
+        expect(timeline.until(terminus).to_a).to eq_time_segments [
           Biz::TimeSegment.new(Time.utc(2006), Time.utc(2006, 2)),
           Biz::TimeSegment.new(Time.utc(2005), Time.utc(2005, 2))
         ]
@@ -84,7 +84,7 @@ RSpec.describe Biz::Timeline::Backward do
       let(:duration) { Biz::Duration.seconds(2) }
 
       it 'returns a period with second precision' do
-        expect(timeline.for(duration).to_a).to eq [
+        expect(timeline.for(duration).to_a).to eq_time_segments [
           Biz::TimeSegment.new(
             Time.utc(2006, 1, 31, 23, 59, 58),
             Time.utc(2006, 2)
@@ -113,7 +113,7 @@ RSpec.describe Biz::Timeline::Backward do
       let(:duration) { Biz::Duration.seconds(in_seconds(days: 15)) }
 
       it 'returns part of the first period' do
-        expect(timeline.for(duration).to_a).to eq [
+        expect(timeline.for(duration).to_a).to eq_time_segments [
           Biz::TimeSegment.new(Time.utc(2006, 1, 17), Time.utc(2006, 2))
         ]
       end
@@ -123,7 +123,7 @@ RSpec.describe Biz::Timeline::Backward do
       let(:duration) { Biz::Duration.seconds(in_seconds(days: 31)) }
 
       it 'returns the first period' do
-        expect(timeline.for(duration).to_a).to eq [
+        expect(timeline.for(duration).to_a).to eq_time_segments [
           Biz::TimeSegment.new(Time.utc(2006), Time.utc(2006, 2))
         ]
       end
@@ -133,7 +133,7 @@ RSpec.describe Biz::Timeline::Backward do
       let(:duration) { Biz::Duration.seconds(in_seconds(days: 62)) }
 
       it 'returns the proper periods' do
-        expect(timeline.for(duration).to_a).to eq [
+        expect(timeline.for(duration).to_a).to eq_time_segments [
           Biz::TimeSegment.new(Time.utc(2006), Time.utc(2006, 2)),
           Biz::TimeSegment.new(Time.utc(2005), Time.utc(2005, 2))
         ]
@@ -144,7 +144,7 @@ RSpec.describe Biz::Timeline::Backward do
       let(:duration) { Biz::Duration.seconds(in_seconds(days: 46)) }
 
       it 'returns the proper periods' do
-        expect(timeline.for(duration).to_a).to eq [
+        expect(timeline.for(duration).to_a).to eq_time_segments [
           Biz::TimeSegment.new(Time.utc(2006), Time.utc(2006, 2)),
           Biz::TimeSegment.new(Time.utc(2005, 1, 17), Time.utc(2005, 2))
         ]

--- a/spec/timeline/forward_spec.rb
+++ b/spec/timeline/forward_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Biz::Timeline::Forward do
       let(:terminus) { Time.utc(2006, 1, 1, 0, 1) }
 
       it 'returns a period with second precision' do
-        expect(timeline.until(terminus).to_a).to eq [
+        expect(timeline.until(terminus).to_a).to eq_time_segments [
           Biz::TimeSegment.new(Time.utc(2006), Time.utc(2006, 1, 1, 0, 1))
         ]
       end
@@ -30,7 +30,7 @@ RSpec.describe Biz::Timeline::Forward do
       let(:terminus) { Time.utc(2007, 3) }
 
       it 'returns the proper periods' do
-        expect(timeline.until(terminus).to_a).to eq [
+        expect(timeline.until(terminus).to_a).to eq_time_segments [
           Biz::TimeSegment.new(Time.utc(2006), Time.utc(2006, 2)),
           Biz::TimeSegment.new(Time.utc(2007), Time.utc(2007, 2))
         ]
@@ -41,7 +41,7 @@ RSpec.describe Biz::Timeline::Forward do
       let(:terminus) { Time.utc(2008) }
 
       it 'returns the proper periods' do
-        expect(timeline.until(terminus).to_a).to eq [
+        expect(timeline.until(terminus).to_a).to eq_time_segments [
           Biz::TimeSegment.new(Time.utc(2006), Time.utc(2006, 2)),
           Biz::TimeSegment.new(Time.utc(2007), Time.utc(2007, 2))
         ]
@@ -60,7 +60,7 @@ RSpec.describe Biz::Timeline::Forward do
       let(:terminus) { Time.utc(2007, 1, 15) }
 
       it 'returns the proper periods' do
-        expect(timeline.until(terminus).to_a).to eq [
+        expect(timeline.until(terminus).to_a).to eq_time_segments [
           Biz::TimeSegment.new(Time.utc(2006), Time.utc(2006, 2)),
           Biz::TimeSegment.new(Time.utc(2007), Time.utc(2007, 1, 15))
         ]
@@ -71,7 +71,7 @@ RSpec.describe Biz::Timeline::Forward do
       let(:terminus) { Time.utc(2007, 2) }
 
       it 'returns the proper periods' do
-        expect(timeline.until(terminus).to_a).to eq [
+        expect(timeline.until(terminus).to_a).to eq_time_segments [
           Biz::TimeSegment.new(Time.utc(2006), Time.utc(2006, 2)),
           Biz::TimeSegment.new(Time.utc(2007), Time.utc(2007, 2))
         ]
@@ -84,7 +84,7 @@ RSpec.describe Biz::Timeline::Forward do
       let(:duration) { Biz::Duration.seconds(2) }
 
       it 'returns a period with second precision' do
-        expect(timeline.for(duration).to_a).to eq [
+        expect(timeline.for(duration).to_a).to eq_time_segments [
           Biz::TimeSegment.new(Time.utc(2006), Time.utc(2006, 1, 1, 0, 0, 2))
         ]
       end
@@ -110,7 +110,7 @@ RSpec.describe Biz::Timeline::Forward do
       let(:duration) { Biz::Duration.seconds(in_seconds(days: 15)) }
 
       it 'returns part of the first period' do
-        expect(timeline.for(duration).to_a).to eq [
+        expect(timeline.for(duration).to_a).to eq_time_segments [
           Biz::TimeSegment.new(Time.utc(2006), Time.utc(2006, 1, 16))
         ]
       end
@@ -120,7 +120,7 @@ RSpec.describe Biz::Timeline::Forward do
       let(:duration) { Biz::Duration.seconds(in_seconds(days: 31)) }
 
       it 'returns the first period' do
-        expect(timeline.for(duration).to_a).to eq [
+        expect(timeline.for(duration).to_a).to eq_time_segments [
           Biz::TimeSegment.new(Time.utc(2006), Time.utc(2006, 2))
         ]
       end
@@ -130,7 +130,7 @@ RSpec.describe Biz::Timeline::Forward do
       let(:duration) { Biz::Duration.seconds(in_seconds(days: 62)) }
 
       it 'returns the proper periods' do
-        expect(timeline.for(duration).to_a).to eq [
+        expect(timeline.for(duration).to_a).to eq_time_segments [
           Biz::TimeSegment.new(Time.utc(2006), Time.utc(2006, 2)),
           Biz::TimeSegment.new(Time.utc(2007), Time.utc(2007, 2))
         ]
@@ -141,7 +141,7 @@ RSpec.describe Biz::Timeline::Forward do
       let(:duration) { Biz::Duration.seconds(in_seconds(days: 46)) }
 
       it 'returns the proper periods' do
-        expect(timeline.for(duration).to_a).to eq [
+        expect(timeline.for(duration).to_a).to eq_time_segments [
           Biz::TimeSegment.new(Time.utc(2006), Time.utc(2006, 2)),
           Biz::TimeSegment.new(Time.utc(2007), Time.utc(2007, 1, 16))
         ]

--- a/spec/timeline/proxy_spec.rb
+++ b/spec/timeline/proxy_spec.rb
@@ -20,7 +20,9 @@ RSpec.describe Biz::Timeline::Proxy do
     }
 
     it 'generates a forward-moving timeline' do
-      expect(timeline.forward.until(Time.utc(2006, 1, 4)).to_a).to eq [
+      expect(
+        timeline.forward.until(Time.utc(2006, 1, 4)).to_a
+      ).to eq_time_segments [
         Biz::TimeSegment.new(
           Time.utc(2006, 1, 2, 9),
           Time.utc(2006, 1, 2, 17)
@@ -52,7 +54,9 @@ RSpec.describe Biz::Timeline::Proxy do
     }
 
     it 'generates a backward-moving timeline' do
-      expect(timeline.backward.until(Time.utc(2006, 1, 3)).to_a).to eq [
+      expect(
+        timeline.backward.until(Time.utc(2006, 1, 3)).to_a
+      ).to eq_time_segments [
         Biz::TimeSegment.new(
           Time.utc(2006, 1, 4, 9),
           Time.utc(2006, 1, 4, 17)


### PR DESCRIPTION
In the end, these gems didn't provide enough value to justify the cost of the additional dependencies.

Inspired by: http://www.mikeperham.com/2016/02/09/kill-your-dependencies/

@zendesk/darko 