### PR TITLE
Revert "Simplify build badge URL"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![biz](http://d26a57ydsghvgx.cloudfront.net/www/public/assets/images/bizlogo.png)
 
 [![Gem Version](https://badge.fury.io/rb/biz.svg)](http://badge.fury.io/rb/biz)
-[![Build Status](https://travis-ci.org/zendesk/biz.svg)](https://travis-ci.org/zendesk/biz)
+[![Build Status](https://travis-ci.org/zendesk/biz.svg?branch=master)](https://travis-ci.org/zendesk/biz)
 [![Code Climate](https://codeclimate.com/github/zendesk/biz/badges/gpa.svg)](https://codeclimate.com/github/zendesk/biz)
 [![Test Coverage](https://codeclimate.com/github/zendesk/biz/badges/coverage.svg)](https://codeclimate.com/github/zendesk/biz)
 [![Dependency Status](https://gemnasium.com/zendesk/biz.svg)](https://gemnasium.com/zendesk/biz)


### PR DESCRIPTION
Psych, it turns out [I knew what I was doing](https://github.com/zendesk/biz/commit/f87f2ce494839f67679aefeedd13e9a2d221310b).

@zendesk/darko 