### PR TITLE
Add ability to intersect schedules

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Biz.configure do |config|
     sat: {'10:00' => '14:00'}
   }
 
-  config.holidays = [Date.new(2014, 1, 1), Date.new(2014, 12, 25)]
+  config.holidays = [Date.new(2016, 1, 1), Date.new(2016, 12, 25)]
 
   config.time_zone = 'America/Los_Angeles'
 end

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Time calculations using business hours.
   - Multiple schedule configurations.
 * Second-level precision on all calculations.
 * Accurate handling of Daylight Saving Time.
+* Schedule intersection.
 * Thread-safe.
 
 ## Anti-Features
@@ -118,6 +119,74 @@ Biz.periods
 #  #<Biz::TimeSegment start_time=2015-04-29 16:00:00 UTC end_time=2015-04-30 00:00:00 UTC>,
 #  #<Biz::TimeSegment start_time=2015-04-28 07:00:00 UTC end_time=2015-04-29 07:00:00 UTC>,
 #  #<Biz::TimeSegment start_time=2015-04-27 20:36:57 UTC end_time=2015-04-28 00:00:00 UTC>]
+```
+
+## Schedule Intersection
+
+An intersection of two schedules can be found using `&`:
+
+```ruby
+schedule_1 = Biz::Schedule.new do |config|
+  config.hours = {
+    mon: {'09:00' => '17:00'},
+    tue: {'10:00' => '16:00'},
+    wed: {'09:00' => '17:00'},
+    thu: {'10:00' => '16:00'},
+    fri: {'09:00' => '17:00'},
+    sat: {'11:00' => '14:30'}
+  }
+
+  config.holidays = [Date.new(2016, 1, 1), Date.new(2016, 12, 25)]
+
+  config.time_zone = 'Etc/UTC'
+end
+
+schedule_2 = Biz::Schedule.new do |config|
+  config.hours = {
+    sun: {'10:00' => '12:00'},
+    mon: {'08:00' => '10:00'},
+    tue: {'11:00' => '15:00'},
+    wed: {'16:00' => '18:00'},
+    thu: {'11:00' => '12:00', '13:00' => '14:00'}
+  }
+
+  config.holidays = [
+    Date.new(2016, 1, 1),
+    Date.new(2016, 7, 4),
+    Date.new(2016, 11, 24)
+  ]
+
+  config.time_zone = 'America/Los_Angeles'
+end
+
+schedule_1 & schedule_2
+```
+
+The resulting schedule will be a combination of the two schedules: an
+intersection of the intervals, a union of the holidays, and the time zone of the
+first schedule.
+
+For the above example, the resulting schedule would be equivalent to one with
+the following configuration:
+
+```ruby
+Biz::Schedule.new do |config|
+  config.hours = {
+    mon: {'09:00' => '10:00'},
+    tue: {'11:00' => '15:00'},
+    wed: {'16:00' => '17:00'},
+    thu: {'11:00' => '12:00', '13:00' => '14:00'}
+  }
+
+  config.holidays = [
+    Date.new(2016, 1, 1),
+    Date.new(2016, 7, 4),
+    Date.new(2016, 11, 24),
+    Date.new(2016, 12, 25)
+  ]
+
+  config.time_zone = 'Etc/UTC'
+end
 ```
 
 ## Core Extensions

--- a/lib/biz.rb
+++ b/lib/biz.rb
@@ -1,7 +1,6 @@
 require 'date'
 require 'delegate'
 require 'forwardable'
-require 'set'
 
 require 'clavius'
 require 'tzinfo'

--- a/lib/biz/configuration.rb
+++ b/lib/biz/configuration.rb
@@ -7,6 +7,8 @@ module Biz
       yield raw if block_given?
 
       Validation.perform(raw)
+
+      raw.freeze
     end
 
     def intervals

--- a/lib/biz/configuration.rb
+++ b/lib/biz/configuration.rb
@@ -23,7 +23,12 @@ module Biz
 
     def holidays
       @holidays ||= begin
-        raw.holidays.map { |date| Holiday.new(date, time_zone) }.freeze
+        raw
+          .holidays
+          .to_set
+          .map { |date| Holiday.new(date, time_zone) }
+          .sort
+          .freeze
       end
     end
 

--- a/lib/biz/configuration.rb
+++ b/lib/biz/configuration.rb
@@ -25,7 +25,7 @@ module Biz
       @holidays ||= begin
         raw
           .holidays
-          .to_set
+          .uniq
           .map { |date| Holiday.new(date, time_zone) }
           .sort
           .freeze
@@ -37,7 +37,7 @@ module Biz
     end
 
     def weekdays
-      @weekdays ||= raw.hours.keys.to_set.freeze
+      @weekdays ||= raw.hours.keys.uniq.freeze
     end
 
     protected

--- a/lib/biz/interval.rb
+++ b/lib/biz/interval.rb
@@ -19,6 +19,10 @@ module Biz
       @time_zone  = time_zone
     end
 
+    attr_reader :start_time,
+                :end_time,
+                :time_zone
+
     delegate wday_symbol: :start_time
 
     def endpoints
@@ -56,12 +60,6 @@ module Biz
       [start_time, end_time, time_zone] <=>
         [other.start_time, other.end_time, other.time_zone]
     end
-
-    protected
-
-    attr_reader :start_time,
-                :end_time,
-                :time_zone
 
   end
 end

--- a/lib/biz/schedule.rb
+++ b/lib/biz/schedule.rb
@@ -46,6 +46,23 @@ module Biz
       Time.new(time_zone)
     end
 
+    def &(other)
+      self.class.new do |config|
+        config.hours = Interval.to_hours(
+          intervals.flat_map { |interval|
+            other
+              .intervals
+              .map { |other_interval| interval & other_interval }
+              .reject(&:empty?)
+          }
+        )
+
+        config.holidays = [*holidays, *other.holidays].map(&:to_date)
+
+        config.time_zone = time_zone.name
+      end
+    end
+
     protected
 
     attr_reader :configuration

--- a/lib/biz/time_segment.rb
+++ b/lib/biz/time_segment.rb
@@ -36,26 +36,16 @@ module Biz
     end
 
     def &(other)
-      self.class.new(
-        lower_bound(other),
-        [lower_bound(other), upper_bound(other)].max
-      )
+      lower_bound = [self, other].map(&:start_time).max
+      upper_bound = [self, other].map(&:end_time).min
+
+      self.class.new(lower_bound, [lower_bound, upper_bound].max)
     end
 
     def <=>(other)
       return unless other.is_a?(self.class)
 
       [start_time, end_time] <=> [other.start_time, other.end_time]
-    end
-
-    private
-
-    def lower_bound(other)
-      [self, other].map(&:start_time).max
-    end
-
-    def upper_bound(other)
-      [self, other].map(&:end_time).min
     end
 
   end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -126,7 +126,28 @@ RSpec.describe Biz::Configuration do
   end
 
   describe '#holidays' do
-    context 'when left unconfigured' do
+    let(:holidays) {
+      [Date.new(2006, 12, 25), Date.new(2006, 1, 1), Date.new(2006, 7, 4)]
+    }
+
+    it 'returns the proper holidays' do
+      expect(configuration.holidays).to eq [
+        Biz::Holiday.new(
+          Date.new(2006, 1, 1),
+          TZInfo::Timezone.get('America/New_York')
+        ),
+        Biz::Holiday.new(
+          Date.new(2006, 7, 4),
+          TZInfo::Timezone.get('America/New_York')
+        ),
+        Biz::Holiday.new(
+          Date.new(2006, 12, 25),
+          TZInfo::Timezone.get('America/New_York')
+        )
+      ]
+    end
+
+    context 'when unconfigured' do
       subject(:configuration) {
         Biz::Configuration.new do |config|
           config.hours     = hours
@@ -139,17 +160,17 @@ RSpec.describe Biz::Configuration do
       end
     end
 
-    it 'returns the proper holidays' do
-      expect(configuration.holidays).to eq [
-        Biz::Holiday.new(
-          Date.new(2006, 1, 1),
-          TZInfo::Timezone.get('America/New_York')
-        ),
-        Biz::Holiday.new(
-          Date.new(2006, 12, 25),
-          TZInfo::Timezone.get('America/New_York')
-        )
-      ]
+    context 'when configured with duplicate holidays' do
+      let(:holidays) { Array.new(3) { Date.new(2006, 1, 1) } }
+
+      it 'removes the duplicate dates' do
+        expect(configuration.holidays).to eq [
+          Biz::Holiday.new(
+            Date.new(2006, 1, 1),
+            TZInfo::Timezone.get('America/New_York')
+          )
+        ]
+      end
     end
   end
 

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -197,7 +197,7 @@ RSpec.describe Biz::Configuration do
 
   describe '#weekdays' do
     it 'returns the active weekdays for the configured schedule' do
-      expect(configuration.weekdays).to eq Set.new(%i[mon tue wed thu fri sat])
+      expect(configuration.weekdays).to eq %i[mon tue wed thu fri sat]
     end
   end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Biz::Configuration do
   end
 
   describe '#intervals' do
-    context 'when left unconfigured' do
+    context 'when unconfigured' do
       subject(:configuration) {
         Biz::Configuration.new do |config|
           config.holidays  = holidays
@@ -175,7 +175,7 @@ RSpec.describe Biz::Configuration do
   end
 
   describe '#time_zone' do
-    context 'when left unconfigured' do
+    context 'when unconfigured' do
       subject(:configuration) {
         Biz::Configuration.new do |config|
           config.hours    = hours

--- a/spec/interval_spec.rb
+++ b/spec/interval_spec.rb
@@ -52,6 +52,24 @@ RSpec.describe Biz::Interval do
     end
   end
 
+  describe '#start_time' do
+    it 'returns the start time' do
+      expect(interval.start_time).to eq Biz::WeekTime.start(start_time)
+    end
+  end
+
+  describe '#end_time' do
+    it 'returns the end time' do
+      expect(interval.end_time).to eq Biz::WeekTime.end(end_time)
+    end
+  end
+
+  describe '#time_zone' do
+    it 'returns the time zone' do
+      expect(interval.time_zone).to eq time_zone
+    end
+  end
+
   describe '#wday_symbol' do
     let(:start_time) { week_minute(wday: 1, hour: 12) }
     let(:end_time)   { week_minute(wday: 2, hour: 12) }

--- a/spec/interval_spec.rb
+++ b/spec/interval_spec.rb
@@ -11,6 +11,91 @@ RSpec.describe Biz::Interval do
     )
   }
 
+  describe '.to_hours' do
+    let(:intervals) {
+      [
+        described_class.new(
+          Biz::WeekTime.start(week_minute(wday: 1, hour: 9)),
+          Biz::WeekTime.end(week_minute(wday: 1, hour: 17)),
+          time_zone
+        ),
+        described_class.new(
+          Biz::WeekTime.start(week_minute(wday: 2, hour: 9)),
+          Biz::WeekTime.end(week_minute(wday: 2, hour: 12)),
+          time_zone
+        ),
+        described_class.new(
+          Biz::WeekTime.start(week_minute(wday: 2, hour: 13)),
+          Biz::WeekTime.end(week_minute(wday: 2, hour: 17)),
+          time_zone
+        ),
+        described_class.new(
+          Biz::WeekTime.start(week_minute(wday: 4, hour: 10)),
+          Biz::WeekTime.end(week_minute(wday: 4, hour: 16)),
+          time_zone
+        ),
+        described_class.new(
+          Biz::WeekTime.start(week_minute(wday: 5, hour: 9)),
+          Biz::WeekTime.end(week_minute(wday: 5, hour: 17)),
+          time_zone
+        )
+      ]
+    }
+
+    it 'returns a configuration hash for the provided intervals' do
+      expect(described_class.to_hours(intervals)).to eq(
+        mon: {'09:00' => '17:00'},
+        tue: {'09:00' => '12:00', '13:00' => '17:00'},
+        thu: {'10:00' => '16:00'},
+        fri: {'09:00' => '17:00'}
+      )
+    end
+  end
+
+  describe '#wday_symbol' do
+    let(:start_time) { week_minute(wday: 1, hour: 12) }
+    let(:end_time)   { week_minute(wday: 2, hour: 12) }
+
+    it 'returns the symbol for the day containing the start time' do
+      expect(interval.wday_symbol).to eq :mon
+    end
+  end
+
+  describe '#endpoints' do
+    it 'returns the interval endpoints' do
+      expect(interval.endpoints).to eq [
+        Biz::WeekTime.start(start_time),
+        Biz::WeekTime.end(end_time)
+      ]
+    end
+  end
+
+  describe '#empty?' do
+    context 'when the start time is before the end time' do
+      let(:start_time) { end_time.pred }
+
+      it 'returns false' do
+        expect(interval.empty?).to eq false
+      end
+    end
+
+    context 'when the start time is equal to the end time' do
+      let(:start_time) { end_time }
+
+      it 'returns true' do
+        expect(interval.empty?).to eq true
+      end
+    end
+
+    context 'when the start time is after the end time' do
+      let(:start_time) { end_time.succ }
+
+      it 'returns true' do
+        expect(interval.empty?).to eq true
+      end
+    end
+  end
+
   describe '#contains?' do
     context 'when the time is before the interval' do
       let(:time) { in_zone('America/New_York') { Time.utc(2006, 1, 2, 11) } }
@@ -53,15 +138,6 @@ RSpec.describe Biz::Interval do
     end
   end
 
-  describe '#endpoints' do
-    it 'returns the interval endpoints' do
-      expect(interval.endpoints).to eq [
-        Biz::WeekTime.start(start_time),
-        Biz::WeekTime.end(end_time)
-      ]
-    end
-  end
-
   describe '#to_time_segment' do
     let(:week) { Biz::Week.new(4) }
 
@@ -97,6 +173,110 @@ RSpec.describe Biz::Interval do
           Biz::TimeSegment.new(
             in_zone('America/Los_Angeles') { Time.utc(2006, 1, 29) },
             in_zone('America/Los_Angeles') { Time.utc(2006, 2, 5) }
+          )
+        )
+      end
+    end
+  end
+
+  describe '#&' do
+    let(:other) {
+      described_class.new(
+        Biz::WeekTime.start(other_start_time),
+        Biz::WeekTime.end(other_end_time),
+        time_zone
+      )
+    }
+
+    context 'when the other interval occurs before the interval' do
+      let(:other_start_time) { week_minute(wday: 0, hour: 9) }
+      let(:other_end_time)   { week_minute(wday: 0, hour: 17) }
+
+      it 'returns a zero-duration interval' do
+        expect(interval & other).to eq(
+          described_class.new(
+            Biz::WeekTime.start(start_time),
+            Biz::WeekTime.end(start_time),
+            time_zone
+          )
+        )
+      end
+    end
+
+    context 'when the other interval starts before the interval' do
+      let(:other_start_time) { week_minute(wday: 1, hour: 8) }
+
+      context 'and ends before the interval' do
+        let(:other_end_time) { week_minute(wday: 1, hour: 12) }
+
+        it 'returns the correct interval' do
+          expect(interval & other).to eq(
+            described_class.new(
+              Biz::WeekTime.start(start_time),
+              Biz::WeekTime.end(other_end_time),
+              time_zone
+            )
+          )
+        end
+      end
+
+      context 'and ends after the interval' do
+        let(:other_end_time) { week_minute(wday: 1, hour: 18) }
+
+        it 'returns the correct interval' do
+          expect(interval & other).to eq(
+            described_class.new(
+              Biz::WeekTime.start(start_time),
+              Biz::WeekTime.end(end_time),
+              time_zone
+            )
+          )
+        end
+      end
+    end
+
+    context 'when the other interval starts after the interval' do
+      let(:other_start_time) { week_minute(wday: 1, hour: 12) }
+
+      context 'and ends before the interval' do
+        let(:other_end_time) { week_minute(wday: 1, hour: 15) }
+
+        it 'returns the correct interval' do
+          expect(interval & other).to eq(
+            described_class.new(
+              Biz::WeekTime.start(other_start_time),
+              Biz::WeekTime.end(other_end_time),
+              time_zone
+            )
+          )
+        end
+      end
+
+      context 'and ends after the interval' do
+        let(:other_end_time) { week_minute(wday: 1, hour: 18) }
+
+        it 'returns the correct interval' do
+          expect(interval & other).to eq(
+            described_class.new(
+              Biz::WeekTime.start(other_start_time),
+              Biz::WeekTime.end(end_time),
+              time_zone
+            )
+          )
+        end
+      end
+    end
+
+    context 'when the other interval occurs after the interval' do
+      let(:other_start_time) { week_minute(wday: 2, hour: 9) }
+      let(:other_end_time)   { week_minute(wday: 2, hour: 17) }
+
+      it 'returns a zero-duration interval' do
+        expect(interval & other).to eq(
+          described_class.new(
+            Biz::WeekTime.start(other_start_time),
+            Biz::WeekTime.end(other_start_time),
+            time_zone
           )
         )
       end

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -141,4 +141,52 @@ RSpec.describe Biz::Schedule do
       )
     end
   end
+
+  describe '#&' do
+    let(:other) {
+      described_class.new do |config|
+        config.hours = {
+          sun: {'10:00' => '12:00'},
+          mon: {'08:00' => '10:00'},
+          tue: {'11:00' => '15:00'},
+          wed: {'16:00' => '18:00'},
+          thu: {'11:00' => '12:00', '13:00' => '14:00'}
+        }
+
+        config.holidays = [
+          Date.new(2006, 1, 1),
+          Date.new(2006, 7, 4),
+          Date.new(2006, 11, 24)
+        ]
+
+        config.time_zone = 'America/Los_Angeles'
+      end
+    }
+
+    it 'returns a new schedule' do
+      expect(schedule & other).to be_a Biz::Schedule
+    end
+
+    it 'configures the schedule with the intersection of intervals' do
+      expect(Biz::Interval.to_hours((schedule & other).intervals)).to eq(
+        mon: {'09:00' => '10:00'},
+        tue: {'11:00' => '15:00'},
+        wed: {'16:00' => '17:00'},
+        thu: {'11:00' => '12:00', '13:00' => '14:00'}
+      )
+    end
+
+    it 'configures the schedule with the union of holidays' do
+      expect((schedule & other).holidays.map(&:to_date)).to eq [
+        Date.new(2006, 1, 1),
+        Date.new(2006, 7, 4),
+        Date.new(2006, 11, 24),
+        Date.new(2006, 12, 25)
+      ]
+    end
+
+    it 'configures the schedule with the original time zone' do
+      expect((schedule & other).time_zone).to eq schedule.time_zone
+    end
+  end
 end

--- a/spec/time_segment_spec.rb
+++ b/spec/time_segment_spec.rb
@@ -50,7 +50,15 @@ RSpec.describe Biz::TimeSegment do
   end
 
   describe '#empty?' do
-    context 'when the start time equals the end time' do
+    context 'when the start time is before the end time' do
+      let(:time_segment) { described_class.new(start_time, start_time + 1) }
+
+      it 'returns false' do
+        expect(time_segment.empty?).to eq false
+      end
+    end
+
+    context 'when the start time is equal to the end time' do
       let(:time_segment) { described_class.new(start_time, start_time) }
 
       it 'returns true' do
@@ -58,11 +66,11 @@ RSpec.describe Biz::TimeSegment do
       end
     end
 
-    context 'when the start time does not equal the end time' do
-      let(:time_segment) { described_class.new(start_time, end_time) }
+    context 'when the start time is after the end time' do
+      let(:time_segment) { described_class.new(end_time + 1, end_time) }
 
-      it 'returns false' do
-        expect(time_segment.empty?).to eq false
+      it 'returns true' do
+        expect(time_segment.empty?).to eq true
       end
     end
   end


### PR DESCRIPTION
An intersection of two schedules consists of:
  * an intersection of intervals
  * a union of holidays
  * the time zone of the first schedule

For example:

```ruby
schedule_1 = Biz::Schedule.new do |config|
  config.hours = {
    mon: {'09:00' => '17:00'},
    tue: {'10:00' => '16:00'},
    wed: {'09:00' => '17:00'},
    thu: {'10:00' => '16:00'},
    fri: {'09:00' => '17:00'},
    sat: {'11:00' => '14:30'}
  }

  config.holidays = [Date.new(2016, 1, 1), Date.new(2016, 12, 25)]

  config.time_zone = 'Etc/UTC'
end

schedule_2 = Biz::Schedule.new do |config|
  config.hours = {
    sun: {'10:00' => '12:00'},
    mon: {'08:00' => '10:00'},
    tue: {'11:00' => '15:00'},
    wed: {'16:00' => '18:00'},
    thu: {'11:00' => '12:00', '13:00' => '14:00'}
  }

  config.holidays = [
    Date.new(2016, 1, 1),
    Date.new(2016, 7, 4),
    Date.new(2016, 11, 24)
  ]

  config.time_zone = 'America/Los_Angeles'
end

schedule_1 & schedule_2
```

results in a schedule that is configured like:

```ruby
Biz::Schedule.new do |config|
  config.hours = {
    mon: {'09:00' => '10:00'},
    tue: {'11:00' => '15:00'},
    wed: {'16:00' => '17:00'},
    thu: {'11:00' => '12:00', '13:00' => '14:00'}
  }

  config.holidays = [
    Date.new(2016, 1, 1),
    Date.new(2016, 7, 4),
    Date.new(2016, 11, 24),
    Date.new(2016, 12, 25)
  ]

  config.time_zone = 'Etc/UTC'
end
```

Closes #50.

@zendesk/darko 

/cc @pocman