### PR TITLE
Allow holiday configuration with array-like objects

### DIFF
--- a/lib/biz/configuration.rb
+++ b/lib/biz/configuration.rb
@@ -25,6 +25,7 @@ module Biz
       @holidays ||= begin
         raw
           .holidays
+          .to_a
           .uniq
           .map { |date| Holiday.new(date, time_zone) }
           .sort

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -172,6 +172,24 @@ RSpec.describe Biz::Configuration do
         ]
       end
     end
+
+    context 'when configured with an array-like object' do
+      let(:holidays) {
+        Class.new do
+          def initialize(holidays)
+            @holidays = holidays
+          end
+
+          def to_a
+            @holidays
+          end
+        end.new([Date.new(2006, 1, 1)])
+      }
+
+      it 'does not blow up' do
+        expect { configuration.holidays }.not_to raise_error
+      end
+    end
   end
 
   describe '#time_zone' do


### PR DESCRIPTION
For example, if passed a set, which doesn't respond to `uniq`, we should coerce to an array before finishing the configuration.

@zendesk/darko 