### PR TITLE
Reject negative scalars in for-duration calculations

### DIFF
--- a/lib/biz.rb
+++ b/lib/biz.rb
@@ -31,7 +31,8 @@ module Biz
     private
 
     def schedule
-      Thread.current[:biz_schedule] or fail "#{name} not configured"
+      Thread.current[:biz_schedule] or
+        fail Error::Configuration, "#{name} not configured"
     end
 
   end

--- a/lib/biz.rb
+++ b/lib/biz.rb
@@ -31,7 +31,7 @@ module Biz
     private
 
     def schedule
-      Thread.current[:biz_schedule] or fail 'Biz has not been configured.'
+      Thread.current[:biz_schedule] or fail "#{name} not configured"
     end
 
   end

--- a/lib/biz/calculation/for_duration.rb
+++ b/lib/biz/calculation/for_duration.rb
@@ -24,7 +24,9 @@ module Biz
 
       def initialize(schedule, scalar)
         @schedule = schedule
-        @scalar   = scalar
+        @scalar   = Integer(scalar)
+
+        fail ArgumentError, 'negative scalar' if @scalar < 0
       end
 
       protected

--- a/lib/biz/calculation/for_duration.rb
+++ b/lib/biz/calculation/for_duration.rb
@@ -11,9 +11,7 @@ module Biz
       end
 
       def self.with_unit(schedule, scalar, unit)
-        unless UNITS.include?(unit)
-          fail ArgumentError, 'The unit is not supported.'
-        end
+        fail ArgumentError, 'unsupported unit' unless UNITS.include?(unit)
 
         public_send(unit, schedule, scalar)
       end

--- a/lib/biz/day_time.rb
+++ b/lib/biz/day_time.rb
@@ -52,7 +52,7 @@ module Biz
       @day_second = Integer(day_second)
 
       unless VALID_SECONDS.cover?(@day_second)
-        fail ArgumentError, 'Invalid number of seconds for a day.'
+        fail ArgumentError, 'second not within a day'
       end
     end
 

--- a/lib/biz/validation.rb
+++ b/lib/biz/validation.rb
@@ -38,10 +38,10 @@ module Biz
     end
 
     RULES = [
-      Rule.new('Hours must be hash-like.') { |raw|
+      Rule.new('hours not hash-like') { |raw|
         raw.hours.respond_to?(:to_h)
       },
-      Rule.new('Hours must be provided.') { |raw|
+      Rule.new('hours not provided') { |raw|
         raw.hours.to_h.any?
       }
     ].freeze

--- a/spec/biz_spec.rb
+++ b/spec/biz_spec.rb
@@ -114,7 +114,9 @@ RSpec.describe Biz do
     before do Thread.current[:biz_schedule] = nil end
 
     it 'fails hard' do
-      expect { described_class.intervals }.to raise_error RuntimeError
+      expect {
+        described_class.intervals
+      }.to raise_error Biz::Error::Configuration
     end
   end
 end

--- a/spec/calculation/for_duration_spec.rb
+++ b/spec/calculation/for_duration_spec.rb
@@ -1,4 +1,46 @@
 RSpec.describe Biz::Calculation::ForDuration do
+  context 'when initializing' do
+    context 'with a valid integer-like scalar' do
+      it 'is successful' do
+        expect { described_class.new(schedule, '1') }.not_to raise_error
+      end
+    end
+
+    context 'with an invalid integer-like scalar' do
+      it 'fails hard' do
+        expect {
+          described_class.new(schedule, '1one')
+        }.to raise_error ArgumentError
+      end
+    end
+
+    context 'with a non-integer scalar' do
+      it 'fails hard' do
+        expect { described_class.new(schedule, []) }.to raise_error TypeError
+      end
+    end
+
+    context 'with a negative scalar' do
+      it 'fails hard' do
+        expect {
+          described_class.new(schedule, -1)
+        }.to raise_error ArgumentError
+      end
+    end
+
+    context 'with a zero scalar' do
+      it 'is successful' do
+        expect { described_class.new(schedule, 0) }.not_to raise_error
+      end
+    end
+
+    context 'with a positive scalar' do
+      it 'is successful' do
+        expect { described_class.new(schedule, 1) }.not_to raise_error
+      end
+    end
+  end
+
   describe '.units' do
     it 'returns the supported units' do
       expect(described_class.units).to eq(

--- a/spec/day_of_week_spec.rb
+++ b/spec/day_of_week_spec.rb
@@ -2,9 +2,9 @@ RSpec.describe Biz::DayOfWeek do
   subject(:day) { described_class.new(1) }
 
   context 'when initializing' do
-    context 'with an valid integer-like value' do
+    context 'with a valid integer-like value' do
       it 'is successful' do
-        expect(described_class.new('1')).to eq described_class.new(1)
+        expect { described_class.new('1') }.not_to raise_error
       end
     end
 

--- a/spec/day_time_spec.rb
+++ b/spec/day_time_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe Biz::DayTime do
   }
 
   context 'when initializing' do
-    context 'with an valid integer-like value' do
+    context 'with a valid integer-like value' do
       it 'is successful' do
-        expect(described_class.new('1').day_second).to eq 1
+        expect { described_class.new('1') }.not_to raise_error
       end
     end
 
@@ -22,23 +22,21 @@ RSpec.describe Biz::DayTime do
       end
     end
 
-    context 'when the value is negative' do
+    context 'with a negative value' do
       it 'fails hard' do
         expect { described_class.new(-1) }.to raise_error ArgumentError
       end
     end
 
-    context 'when the value is zero' do
+    context 'when a zero value' do
       it 'is successful' do
-        expect(described_class.new(0).day_second).to eq 0
+        expect { described_class.new(0).day_second }.not_to raise_error
       end
     end
 
     context 'when the value is the number of seconds in a day' do
       it 'is successful' do
-        expect(described_class.new(Biz::Time.day_seconds).day_second).to eq(
-          Biz::Time.day_seconds
-        )
+        expect { described_class.new(Biz::Time.day_seconds) }.not_to raise_error
       end
     end
 

--- a/spec/duration_spec.rb
+++ b/spec/duration_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe Biz::Duration do
   }
 
   context 'when initializing' do
-    context 'with an valid integer-like value' do
+    context 'with a valid integer-like value' do
       it 'is successful' do
-        expect(described_class.new('1')).to eq described_class.new(1)
+        expect { described_class.new('1') }.not_to raise_error
       end
     end
 

--- a/spec/validation_spec.rb
+++ b/spec/validation_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe Biz::Validation do
     before do raw.hours = {} end
 
     it 'performs the validation on the provided raw input' do
-      expect { described_class.perform(raw) }.to raise_error(
-        Biz::Error::Configuration
-      )
+      expect {
+        described_class.perform(raw)
+      }.to raise_error Biz::Error::Configuration
     end
   end
 

--- a/spec/week_spec.rb
+++ b/spec/week_spec.rb
@@ -2,9 +2,9 @@ RSpec.describe Biz::Week do
   subject(:week) { described_class.new(2) }
 
   context 'when initializing' do
-    context 'with an valid integer-like value' do
+    context 'with a valid integer-like value' do
       it 'is successful' do
-        expect(described_class.new('1')).to be_truthy
+        expect { described_class.new('1') }.not_to raise_error
       end
     end
 

--- a/spec/week_time/abstract_spec.rb
+++ b/spec/week_time/abstract_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe Biz::WeekTime::Abstract do
   }
 
   context 'when initializing' do
-    context 'with an valid integer-like value' do
+    context 'with a valid integer-like value' do
       it 'is successful' do
-        expect(week_time_class.new('1')).to eq week_time_class.new(1)
+        expect { week_time_class.new('1') }.not_to raise_error
       end
     end
 


### PR DESCRIPTION
Negative scalars are not something we want to explicitly support at this time, so we'll raise a helpful error message instead of randomly blowing up when someone tries to do it.

This also includes a bit of work to streamline and standardize exceptions.

Fixes #59.

@alex-stone @joshlam @kpandya91 @kbrainwave 

/cc @mwean