### PR TITLE
Add holiday performance improvement tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,12 @@ Biz.in_hours?(Time.utc(2015, 1, 10, 9))
 Biz.on_holiday?(Time.utc(2014, 1, 1))
 ```
 
-Note that all returned times are in UTC.
+All returned times are in UTC.
+
+If a schedule will be configured with a large number of holidays and performance
+is a particular concern, it's recommended that holidays are filtered down to
+those relevant to the calculation(s) at hand before configuration to improve
+performance.
 
 By dropping down a level, you can get access to the underlying time segments,
 which you can use to do your own custom calculations or just get a better idea

--- a/lib/biz/periods/abstract.rb
+++ b/lib/biz/periods/abstract.rb
@@ -39,10 +39,6 @@ module Biz
         intervals.lazy.map { |interval| interval.to_time_segment(week) }
       end
 
-      def intervals
-        schedule.intervals
-      end
-
     end
   end
 end

--- a/lib/biz/periods/abstract.rb
+++ b/lib/biz/periods/abstract.rb
@@ -11,8 +11,6 @@ module Biz
         super(periods) do |yielder, period| yielder << period end
       end
 
-      delegate time_zone: :schedule
-
       def timeline
         Timeline::Proxy.new(self)
       end

--- a/lib/biz/periods/after.rb
+++ b/lib/biz/periods/after.rb
@@ -20,7 +20,11 @@ module Biz
       end
 
       def boundary
-        TimeSegment.after(origin)
+        @boundary ||= TimeSegment.after(origin)
+      end
+
+      def intervals
+        @intervals ||= schedule.intervals
       end
 
     end

--- a/lib/biz/periods/after.rb
+++ b/lib/biz/periods/after.rb
@@ -10,7 +10,7 @@ module Biz
 
       def weeks
         Range.new(
-          Week.since_epoch(Time.new(time_zone).local(origin)),
+          Week.since_epoch(schedule.in_zone.local(origin)),
           Week.since_epoch(Time.heat_death)
         )
       end

--- a/lib/biz/periods/before.rb
+++ b/lib/biz/periods/before.rb
@@ -10,7 +10,7 @@ module Biz
 
       def weeks
         Week
-          .since_epoch(Time.new(time_zone).local(origin))
+          .since_epoch(schedule.in_zone.local(origin))
           .downto(Week.since_epoch(Time.big_bang))
       end
 

--- a/lib/biz/periods/before.rb
+++ b/lib/biz/periods/before.rb
@@ -19,11 +19,11 @@ module Biz
       end
 
       def boundary
-        TimeSegment.before(origin)
+        @boundary ||= TimeSegment.before(origin)
       end
 
       def intervals
-        super.reverse
+        @intervals ||= schedule.intervals.reverse
       end
 
     end


### PR DESCRIPTION
Calculations will slow down as the number of configured holidays increases. Unfortunately, there isn't an easy way to optimize for this in the period generator a priori because we simply don't know when the
generator will stop being asked for periods, and consequently, which holidays are actually relevant.

Since this could be a concern for some performance-sensitive users, let's add a tip to the `README` to help them out.

Closes #63.

@zendesk/darko 

/cc @pocman