### PR TITLE
Filter out empty generated intervals

### DIFF
--- a/lib/biz/periods/abstract.rb
+++ b/lib/biz/periods/abstract.rb
@@ -26,17 +26,20 @@ module Biz
         weeks
           .lazy
           .flat_map { |week| business_periods(week) }
-          .select   { |business_period| relevant?(business_period) }
-          .map      { |business_period| business_period & boundary }
-          .reject   { |business_period|
-            schedule.holidays.any? { |holiday|
-              holiday.contains?(business_period.start_time)
-            }
-          }
+          .select   { |period| relevant?(period) }
+          .map      { |period| period & boundary }
+          .reject   { |period| on_holiday?(period) }
+          .reject(&:empty?)
       end
 
       def business_periods(week)
         intervals.lazy.map { |interval| interval.to_time_segment(week) }
+      end
+
+      def on_holiday?(period)
+        schedule.holidays.any? { |holiday|
+          holiday.contains?(period.start_time)
+        }
       end
 
     end

--- a/spec/periods/after_spec.rb
+++ b/spec/periods/after_spec.rb
@@ -173,15 +173,29 @@ RSpec.describe Biz::Periods::After do
     let(:hours)     { {sat: {'06:00' => '18:00'}} }
     let(:time_zone) { 'America/Los_Angeles' }
 
-    let(:origin) {
-      in_zone('America/Los_Angeles') { Time.utc(2006, 1, 7, 17) }
-    }
+    let(:origin) { in_zone('America/Los_Angeles') { Time.utc(2006, 1, 7, 17) } }
 
     it 'includes the relevant interval from the prior week' do
       expect(periods.first).to eq(
         Biz::TimeSegment.new(
           in_zone('America/Los_Angeles') { Time.utc(2006, 1, 7, 17) },
           in_zone('America/Los_Angeles') { Time.utc(2006, 1, 7, 18) }
+        )
+      )
+    end
+  end
+
+  context 'when an empty interval is generated' do
+    let(:hours)     { {sun: {'02:30' => '03:15'}, mon: {'09:00' => '17:00'}} }
+    let(:time_zone) { 'America/Los_Angeles' }
+
+    let(:origin) { in_zone('America/Los_Angeles') { Time.utc(2006, 4, 2) } }
+
+    it 'is filtered out' do
+      expect(periods.first).to eq(
+        Biz::TimeSegment.new(
+          in_zone('America/Los_Angeles') { Time.utc(2006, 4, 3, 9) },
+          in_zone('America/Los_Angeles') { Time.utc(2006, 4, 3, 17) }
         )
       )
     end


### PR DESCRIPTION
When short intervals are generated around the DST spring-forward point, it's possible to generate nonsensical empty intervals because of how the logic compensates for impossible times during the spring-forward hour by adding an hour to the time.

Due to this possibility, the period generator should protect against these empty intervals before emitting a period.

@zendesk/darko 