### PR TITLE
Implement "breaks" (time-segment holidays) feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,15 @@ Time calculations using business hours.
 ## Features
 
 * Support for:
-  - Intervals spanning the entire day.
-  - Interday intervals and holidays.
   - Multiple intervals per day.
   - Multiple schedule configurations.
-* Second-level precision on all calculations.
-* Accurate handling of Daylight Saving Time.
+  - Intervals spanning the entire day.
+  - Holidays.
+  - Breaks (time-segment holidays).
+* Second-level calculation precision.
+* Seamless Daylight Saving Time handling.
 * Schedule intersection.
-* Thread-safe.
+* Thread safety.
 
 ## Anti-Features
 
@@ -51,11 +52,19 @@ Biz.configure do |config|
     sat: {'10:00' => '14:00'}
   }
 
+  config.breaks = {
+    Date.new(2006, 1, 2) => {'10:00' => '11:30'},
+    Date.new(2006, 1, 3) => {'14:15' => '14:30', '15:40' => '15:50'}
+  }
+
   config.holidays = [Date.new(2016, 1, 1), Date.new(2016, 12, 25)]
 
   config.time_zone = 'America/Los_Angeles'
 end
 ```
+
+Periods occurring on holidays are disregarded. Similarly, any segment of a
+period that overlaps with a break is treated as inactive.
 
 If global configuration isn't your thing, configure an instance instead:
 

--- a/lib/biz/periods/abstract.rb
+++ b/lib/biz/periods/abstract.rb
@@ -28,12 +28,19 @@ module Biz
           .flat_map { |week| business_periods(week) }
           .select   { |period| relevant?(period) }
           .map      { |period| period & boundary }
+          .flat_map { |period| active_periods(period) }
           .reject   { |period| on_holiday?(period) }
           .reject(&:empty?)
       end
 
       def business_periods(week)
         intervals.lazy.map { |interval| interval.to_time_segment(week) }
+      end
+
+      def active_periods(period)
+        schedule.breaks.reduce([period]) { |periods, break_period|
+          periods.flat_map { |active_period| active_period / break_period }
+        }
       end
 
       def on_holiday?(period)

--- a/lib/biz/periods/before.rb
+++ b/lib/biz/periods/before.rb
@@ -18,6 +18,10 @@ module Biz
         origin > period.start_time
       end
 
+      def active_periods(*)
+        super.reverse
+      end
+
       def boundary
         @boundary ||= TimeSegment.before(origin)
       end

--- a/lib/biz/schedule.rb
+++ b/lib/biz/schedule.rb
@@ -9,6 +9,7 @@ module Biz
 
     delegate %i[
       intervals
+      breaks
       holidays
       time_zone
       weekdays

--- a/lib/biz/time_segment.rb
+++ b/lib/biz/time_segment.rb
@@ -42,6 +42,13 @@ module Biz
       self.class.new(lower_bound, [lower_bound, upper_bound].max)
     end
 
+    def /(other)
+      [
+        self.class.new(start_time, other.start_time),
+        self.class.new(other.end_time, end_time)
+      ].reject(&:empty?).map { |potential| self & potential }
+    end
+
     def <=>(other)
       return unless other.is_a?(self.class)
 

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -9,11 +9,21 @@ RSpec.describe Biz::Schedule do
       sat: {'11:00' => '14:30'}
     }
   }
+
+  let(:breaks) {
+    {
+      Date.new(2006, 1, 2) => {'10:00' => '11:30'},
+      Date.new(2006, 1, 3) => {'14:15' => '14:30', '15:40' => '15:50'}
+    }
+  }
+
   let(:holidays)  { [Date.new(2006, 1, 1), Date.new(2006, 12, 25)] }
   let(:time_zone) { 'Etc/UTC' }
-  let(:config)    {
+
+  let(:config) {
     proc do |c|
       c.hours     = hours
+      c.breaks    = breaks
       c.holidays  = holidays
       c.time_zone = time_zone
     end
@@ -24,6 +34,12 @@ RSpec.describe Biz::Schedule do
   describe '#intervals' do
     it 'delegates to the configuration' do
       expect(schedule.intervals).to eq Biz::Configuration.new(&config).intervals
+    end
+  end
+
+  describe '#breaks' do
+    it 'delegates to the configuration' do
+      expect(schedule.breaks).to eq Biz::Configuration.new(&config).breaks
     end
   end
 
@@ -73,7 +89,7 @@ RSpec.describe Biz::Schedule do
   describe '#within' do
     it 'returns the amount of elapsed business time between two times' do
       expect(
-        schedule.within(Time.utc(2006, 1, 2, 11), Time.utc(2006, 1, 3, 11))
+        schedule.within(Time.utc(2006, 1, 5, 12), Time.utc(2006, 1, 6, 12))
       ).to eq Biz::Duration.hours(7)
     end
   end

--- a/spec/support/time.rb
+++ b/spec/support/time.rb
@@ -37,8 +37,8 @@ module Biz
               sat: {'11:00' => '14:30'}
             )
 
-            config.holidays = args.fetch(:holidays, [])
-
+            config.breaks    = args.fetch(:breaks, {})
+            config.holidays  = args.fetch(:holidays, [])
             config.time_zone = args.fetch(:time_zone, 'Etc/UTC')
           end
         end

--- a/spec/time_segment_spec.rb
+++ b/spec/time_segment_spec.rb
@@ -191,6 +191,75 @@ RSpec.describe Biz::TimeSegment do
     end
   end
 
+  describe '#/' do
+    let(:other) { described_class.new(other_start_time, other_end_time) }
+
+    context 'when the other segment occurs before the time segment' do
+      let(:other_start_time) { Time.utc(2006, 1, 1) }
+      let(:other_end_time)   { Time.utc(2006, 1, 2) }
+
+      it 'returns the original time segment' do
+        expect(time_segment / other).to eq [time_segment]
+      end
+    end
+
+    context 'when the other segment starts before the time segment' do
+      let(:other_start_time) { Time.utc(2006, 1, 7) }
+
+      context 'and ends before the time segment' do
+        let(:other_end_time) { Time.utc(2006, 1, 8, 11, 45) }
+
+        it 'returns the correct time segment' do
+          expect(time_segment / other).to eq [
+            described_class.new(other.end_time, time_segment.end_time)
+          ]
+        end
+      end
+
+      context 'and ends after the time segment' do
+        let(:other_end_time) { Time.utc(2006, 1, 23) }
+
+        it 'returns an empty array' do
+          expect(time_segment / other).to eq []
+        end
+      end
+    end
+
+    context 'when the other segment starts after the time segment' do
+      let(:other_start_time) { Time.utc(2006, 1, 8, 11, 30) }
+
+      context 'and ends before the time segment' do
+        let(:other_end_time) { Time.utc(2006, 1, 9, 12, 30) }
+
+        it 'returns the correct time segments' do
+          expect(time_segment / other).to eq [
+            described_class.new(time_segment.start_time, other.start_time),
+            described_class.new(other.end_time, time_segment.end_time)
+          ]
+        end
+      end
+
+      context 'and ends after the time segment' do
+        let(:other_end_time) { Time.utc(2006, 1, 23) }
+
+        it 'returns the correct time segment' do
+          expect(time_segment / other).to eq [
+            described_class.new(time_segment.start_time, other.start_time)
+          ]
+        end
+      end
+    end
+
+    context 'when the other segment occurs after the time segment' do
+      let(:other_start_time) { Time.utc(2006, 2, 1) }
+      let(:other_end_time)   { Time.utc(2006, 2, 7) }
+
+      it 'returns the original time segment' do
+        expect(time_segment / other).to eq [time_segment]
+      end
+    end
+  end
+
   context 'when performing comparison' do
     context 'and the compared object has an earlier start time' do
       let(:other) { described_class.new(start_time - 1, end_time) }


### PR DESCRIPTION
Similar to holidays, time during a break is treated as inactive, regardless of whether there is an active overlapping time segment.

Although this feature is fundamentally similar to holidays, it is implemented separately in order to keep optimizations related to holidays that make those calculations [approximately 3x faster](https://github.com/zendesk/biz/commit/7b8b56597732c69114337966eb6c4f64ff2726e4) than equivalent break-based calculations.

Check out the added specs for a more complete understanding of how this feature operates in a variety of scenarios.

@zendesk/darko 

/cc @chrismahon