### PR TITLE
Consider breaks in `in_hours?` calculation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+Metrics/AbcSize:
+  Max: 20
+
 Metrics/MethodLength:
   Max: 20
 

--- a/lib/biz/calculation/active.rb
+++ b/lib/biz/calculation/active.rb
@@ -8,7 +8,8 @@ module Biz
       end
 
       def result
-        schedule.intervals.any? { |interval| interval.contains?(time) } &&
+        schedule.intervals.any?   { |interval| interval.contains?(time) } &&
+          schedule.breaks.none?   { |break_| break_.contains?(time) } &&
           schedule.holidays.none? { |holiday| holiday.contains?(time) }
       end
 

--- a/spec/calculation/active_spec.rb
+++ b/spec/calculation/active_spec.rb
@@ -1,12 +1,26 @@
 RSpec.describe Biz::Calculation::Active do
   subject(:calculation) {
-    described_class.new(schedule(holidays: [Date.new(2006, 1, 4)]), time)
+    described_class.new(
+      schedule(
+        breaks:   {Date.new(2006, 1, 3) => {'05:30' => '11:00'}},
+        holidays: [Date.new(2006, 1, 4)]
+      ),
+      time
+    )
   }
 
   describe '#result' do
     context 'when the time is not contained by an interval' do
-      context 'and not on a holiday' do
+      context 'and not on a break nor holiday' do
         let(:time) { Time.utc(2006, 1, 1, 6) }
+
+        it 'returns false' do
+          expect(calculation.result).to eq false
+        end
+      end
+
+      context 'and on a break' do
+        let(:time) { Time.utc(2006, 1, 3, 6) }
 
         it 'returns false' do
           expect(calculation.result).to eq false
@@ -23,11 +37,19 @@ RSpec.describe Biz::Calculation::Active do
     end
 
     context 'when the time is contained by an interval' do
-      context 'and not on a holiday' do
+      context 'and not on a break nor holiday' do
         let(:time) { Time.utc(2006, 1, 2, 12) }
 
         it 'returns true' do
           expect(calculation.result).to eq true
+        end
+      end
+
+      context 'and on a break' do
+        let(:time) { Time.utc(2006, 1, 3, 10) }
+
+        it 'returns false' do
+          expect(calculation.result).to eq false
         end
       end
 

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Biz::Schedule do
     end
 
     context 'when the time is in business hours' do
-      let(:time) { Time.utc(2006, 1, 2, 10) }
+      let(:time) { Time.utc(2006, 1, 2, 12) }
 
       it 'returns true' do
         expect(schedule.in_hours?(time)).to eq true
@@ -122,7 +122,7 @@ RSpec.describe Biz::Schedule do
     end
 
     context 'when the time is in business hours' do
-      let(:time) { Time.utc(2006, 1, 2, 10) }
+      let(:time) { Time.utc(2006, 1, 2, 12) }
 
       it 'returns true' do
         expect(schedule.business_hours?(time)).to eq true


### PR DESCRIPTION
Since the calculation behind `in_hours?` is optimized to avoid period generation, we need to take extra steps to ensure it takes breaks into consideration.

Closes #69.

@zendesk/darko 

/cc @aserafin