### PR TITLE
Include breaks when intersecting schedules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
 Metrics/AbcSize:
   Max: 20
 
+Metrics/ClassLength:
+  Max: 120
+
 Metrics/MethodLength:
   Max: 20
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,11 @@ schedule_1 = Biz::Schedule.new do |config|
     sat: {'11:00' => '14:30'}
   }
 
+  config.breaks = {
+    Date.new(2016, 6, 2) => {'09:00' => '10:30', '16:00' => '16:30'},
+    Date.new(2016, 6, 3) => {'12:15' => '12:45'}
+  }
+
   config.holidays = [Date.new(2016, 1, 1), Date.new(2016, 12, 25)]
 
   config.time_zone = 'Etc/UTC'
@@ -162,6 +167,11 @@ schedule_2 = Biz::Schedule.new do |config|
     tue: {'11:00' => '15:00'},
     wed: {'16:00' => '18:00'},
     thu: {'11:00' => '12:00', '13:00' => '14:00'}
+  }
+
+  config.breaks = {
+    Date.new(2016, 6, 3) => {'13:30' => '14:00'},
+    Date.new(2016, 6, 4) => {'11:00' => '12:00'}
   }
 
   config.holidays = [
@@ -177,8 +187,8 @@ schedule_1 & schedule_2
 ```
 
 The resulting schedule will be a combination of the two schedules: an
-intersection of the intervals, a union of the holidays, and the time zone of the
-first schedule.
+intersection of the intervals, a union of the breaks and holidays, and the time
+zone of the first schedule.
 
 For the above example, the resulting schedule would be equivalent to one with
 the following configuration:
@@ -190,6 +200,12 @@ Biz::Schedule.new do |config|
     tue: {'11:00' => '15:00'},
     wed: {'16:00' => '17:00'},
     thu: {'11:00' => '12:00', '13:00' => '14:00'}
+  }
+
+  config.breaks = {
+    Date.new(2016, 6, 2) => {'09:00' => '10:30', '16:00' => '16:30'},
+    Date.new(2016, 6, 3) => {'12:15' => '12:45', '13:30' => '14:00'},
+    Date.new(2016, 6, 4) => {'11:00' => '12:00'}
   }
 
   config.holidays = [

--- a/lib/biz/schedule.rb
+++ b/lib/biz/schedule.rb
@@ -48,27 +48,12 @@ module Biz
     end
 
     def &(other)
-      self.class.new do |config|
-        config.hours     = Interval.to_hours(intersected_intervals(other))
-        config.holidays  = [*holidays, *other.holidays].map(&:to_date)
-        config.time_zone = time_zone.name
-      end
+      self.class.new(&(configuration & other.configuration))
     end
 
     protected
 
     attr_reader :configuration
-
-    private
-
-    def intersected_intervals(other)
-      intervals.flat_map { |interval|
-        other
-          .intervals
-          .map { |other_interval| interval & other_interval }
-          .reject(&:empty?)
-      }
-    end
 
   end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -267,6 +267,8 @@ RSpec.describe Biz::Configuration do
           thu: {'11:00' => '12:00', '13:00' => '14:00'}
         }
 
+        config.breaks = {Date.new(2006, 1, 3) => {'11:15' => '11:45'}}
+
         config.holidays = [
           Date.new(2006, 1, 1),
           Date.new(2006, 7, 4),
@@ -288,6 +290,27 @@ RSpec.describe Biz::Configuration do
         wed: {'16:00' => '17:00'},
         thu: {'11:00' => '12:00', '13:00' => '14:00'}
       )
+    end
+
+    it 'unions the breaks' do
+      expect((configuration & other).breaks).to eq [
+        Biz::TimeSegment.new(
+          in_zone('America/New_York') { Time.new(2006, 1, 2, 10) },
+          in_zone('America/New_York') { Time.new(2006, 1, 2, 11, 30) }
+        ),
+        Biz::TimeSegment.new(
+          in_zone('America/New_York') { Time.new(2006, 1, 3, 11, 15) },
+          in_zone('America/New_York') { Time.new(2006, 1, 3, 11, 45) }
+        ),
+        Biz::TimeSegment.new(
+          in_zone('America/New_York') { Time.new(2006, 1, 3, 14, 15) },
+          in_zone('America/New_York') { Time.new(2006, 1, 3, 14, 30) }
+        ),
+        Biz::TimeSegment.new(
+          in_zone('America/New_York') { Time.new(2006, 1, 3, 15, 40) },
+          in_zone('America/New_York') { Time.new(2006, 1, 3, 15, 50) }
+        )
+      ]
     end
 
     it 'unions the holidays' do

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -45,6 +45,22 @@ RSpec.describe Biz::Configuration do
     end
   end
 
+  context 'when converted to a proc for configuration' do
+    let(:proc_configuration) { described_class.new(&configuration) }
+
+    it 'configures the intervals' do
+      expect(proc_configuration.intervals).to eq configuration.intervals
+    end
+
+    it 'configures the holidays' do
+      expect(proc_configuration.holidays).to eq configuration.holidays
+    end
+
+    it 'configures the time zone' do
+      expect(proc_configuration.time_zone).to eq configuration.time_zone
+    end
+  end
+
   describe '#intervals' do
     context 'when unconfigured' do
       subject(:configuration) {
@@ -237,6 +253,54 @@ RSpec.describe Biz::Configuration do
   describe '#weekdays' do
     it 'returns the active weekdays for the configured schedule' do
       expect(configuration.weekdays).to eq %i[mon tue wed thu fri sat]
+    end
+  end
+
+  describe '#&' do
+    let(:other) {
+      described_class.new do |config|
+        config.hours = {
+          sun: {'10:00' => '12:00'},
+          mon: {'08:00' => '10:00'},
+          tue: {'11:00' => '15:00'},
+          wed: {'16:00' => '18:00'},
+          thu: {'11:00' => '12:00', '13:00' => '14:00'}
+        }
+
+        config.holidays = [
+          Date.new(2006, 1, 1),
+          Date.new(2006, 7, 4),
+          Date.new(2006, 11, 24)
+        ]
+
+        config.time_zone = 'Etc/UTC'
+      end
+    }
+
+    it 'returns a new configuration' do
+      expect(configuration & other).to be_a Biz::Configuration
+    end
+
+    it 'intersects the intervals' do
+      expect(Biz::Interval.to_hours((configuration & other).intervals)).to eq(
+        mon: {'09:00' => '10:00'},
+        tue: {'11:00' => '15:00'},
+        wed: {'16:00' => '17:00'},
+        thu: {'11:00' => '12:00', '13:00' => '14:00'}
+      )
+    end
+
+    it 'unions the holidays' do
+      expect((configuration & other).holidays.map(&:to_date)).to eq [
+        Date.new(2006, 1, 1),
+        Date.new(2006, 7, 4),
+        Date.new(2006, 11, 24),
+        Date.new(2006, 12, 25)
+      ]
+    end
+
+    it 'uses the original time zone' do
+      expect((configuration & other).time_zone).to eq configuration.time_zone
     end
   end
 end

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -179,30 +179,13 @@ RSpec.describe Biz::Schedule do
       end
     }
 
-    it 'returns a new schedule' do
-      expect(schedule & other).to be_a Biz::Schedule
-    end
-
-    it 'configures the schedule with the intersection of intervals' do
-      expect(Biz::Interval.to_hours((schedule & other).intervals)).to eq(
-        mon: {'09:00' => '10:00'},
-        tue: {'11:00' => '15:00'},
-        wed: {'16:00' => '17:00'},
-        thu: {'11:00' => '12:00', '13:00' => '14:00'}
-      )
-    end
-
-    it 'configures the schedule with the union of holidays' do
-      expect((schedule & other).holidays.map(&:to_date)).to eq [
-        Date.new(2006, 1, 1),
-        Date.new(2006, 7, 4),
-        Date.new(2006, 11, 24),
-        Date.new(2006, 12, 25)
+    it 'returns an intersected schedule' do
+      expect(
+        (schedule & other).periods.after(Time.utc(2006, 1, 1)).take(2).to_a
+      ).to eq [
+        Biz::TimeSegment.new(Time.utc(2006, 1, 2, 9), Time.utc(2006, 1, 2, 10)),
+        Biz::TimeSegment.new(Time.utc(2006, 1, 3, 11), Time.utc(2006, 1, 3, 15))
       ]
-    end
-
-    it 'configures the schedule with the original time zone' do
-      expect((schedule & other).time_zone).to eq schedule.time_zone
     end
   end
 end

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -169,6 +169,8 @@ RSpec.describe Biz::Schedule do
           thu: {'11:00' => '12:00', '13:00' => '14:00'}
         }
 
+        config.breaks = {Date.new(2006, 1, 3) => {'11:15' => '11:45'}}
+
         config.holidays = [
           Date.new(2006, 1, 1),
           Date.new(2006, 7, 4),
@@ -181,10 +183,20 @@ RSpec.describe Biz::Schedule do
 
     it 'returns an intersected schedule' do
       expect(
-        (schedule & other).periods.after(Time.utc(2006, 1, 1)).take(2).to_a
+        (schedule & other).periods.after(Time.utc(2006, 1, 1)).take(3).to_a
       ).to eq [
-        Biz::TimeSegment.new(Time.utc(2006, 1, 2, 9), Time.utc(2006, 1, 2, 10)),
-        Biz::TimeSegment.new(Time.utc(2006, 1, 3, 11), Time.utc(2006, 1, 3, 15))
+        Biz::TimeSegment.new(
+          Time.utc(2006, 1, 2, 9),
+          Time.utc(2006, 1, 2, 10)
+        ),
+        Biz::TimeSegment.new(
+          Time.utc(2006, 1, 3, 11),
+          Time.utc(2006, 1, 3, 11, 15)
+        ),
+        Biz::TimeSegment.new(
+          Time.utc(2006, 1, 3, 11, 45),
+          Time.utc(2006, 1, 3, 14, 15)
+        )
       ]
     end
   end


### PR DESCRIPTION
Breaks are treated similarly to holidays in that they are unioned together in the new schedule.

This PR also includes work to push the intersection logic down into the `Configuration` object.

@zendesk/darko 