### PR TITLE
Add `on_break?` schedule method

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ Biz.within(Time.utc(2015, 3, 7), Time.utc(2015, 3, 14)).in_seconds
 # Determine if a time is in business hours
 Biz.in_hours?(Time.utc(2015, 1, 10, 9))
 
+# Determine if a time is on a break
+Biz.on_break?(Time.utc(2016, 6, 3))
+
 # Determine if a time is on a holiday
 Biz.on_holiday?(Time.utc(2014, 1, 1))
 ```
@@ -236,6 +239,8 @@ require 'biz/core_ext'
 3.business_days.before(Time.utc(2015, 5, 9, 4, 12))
 
 Time.utc(2015, 8, 20, 9, 30).business_hours?
+
+Time.utc(2016, 6, 3, 12).on_break?
 
 Time.utc(2014, 1, 1, 12).on_holiday?
 

--- a/README.md
+++ b/README.md
@@ -95,10 +95,10 @@ Biz.within(Time.utc(2015, 3, 7), Time.utc(2015, 3, 14)).in_seconds
 # Determine if a time is in business hours
 Biz.in_hours?(Time.utc(2015, 1, 10, 9))
 
-# Determine if a time is on a break
+# Determine if a time is during a break
 Biz.on_break?(Time.utc(2016, 6, 3))
 
-# Determine if a time is on a holiday
+# Determine if a time is during a holiday
 Biz.on_holiday?(Time.utc(2014, 1, 1))
 ```
 

--- a/lib/biz.rb
+++ b/lib/biz.rb
@@ -25,6 +25,7 @@ module Biz
       within
       in_hours?
       business_hours?
+      on_break?
       on_holiday?
     ] => :schedule
 

--- a/lib/biz/calculation.rb
+++ b/lib/biz/calculation.rb
@@ -6,4 +6,5 @@ end
 require 'biz/calculation/active'
 require 'biz/calculation/duration_within'
 require 'biz/calculation/for_duration'
+require 'biz/calculation/on_break'
 require 'biz/calculation/on_holiday'

--- a/lib/biz/calculation/on_break.rb
+++ b/lib/biz/calculation/on_break.rb
@@ -1,0 +1,21 @@
+module Biz
+  module Calculation
+    class OnBreak
+
+      def initialize(schedule, time)
+        @schedule = schedule
+        @time     = time
+      end
+
+      def result
+        schedule.breaks.any? { |break_| break_.contains?(time) }
+      end
+
+      protected
+
+      attr_reader :schedule,
+                  :time
+
+    end
+  end
+end

--- a/lib/biz/core_ext/time.rb
+++ b/lib/biz/core_ext/time.rb
@@ -5,6 +5,10 @@ module Biz
         Biz.in_hours?(self)
       end
 
+      def on_break?
+        Biz.on_break?(self)
+      end
+
       def on_holiday?
         Biz.on_holiday?(self)
       end

--- a/lib/biz/holiday.rb
+++ b/lib/biz/holiday.rb
@@ -1,6 +1,8 @@
 module Biz
   class Holiday
 
+    extend Forwardable
+
     include Comparable
 
     def initialize(date, time_zone)
@@ -8,15 +10,15 @@ module Biz
       @time_zone = time_zone
     end
 
-    def contains?(time)
-      date == Time.new(time_zone).local(time).to_date
-    end
+    delegate contains?: :to_time_segment
 
     def to_time_segment
-      TimeSegment.new(
-        Time.new(time_zone).on_date(date, DayTime.midnight),
-        Time.new(time_zone).on_date(date, DayTime.endnight)
-      )
+      @time_segment ||= begin
+        TimeSegment.new(
+          Time.new(time_zone).on_date(date, DayTime.midnight),
+          Time.new(time_zone).on_date(date, DayTime.endnight)
+        )
+      end
     end
 
     def <=>(other)

--- a/lib/biz/schedule.rb
+++ b/lib/biz/schedule.rb
@@ -37,11 +37,15 @@ module Biz
       Calculation::Active.new(self, time).result
     end
 
+    alias business_hours? in_hours?
+
+    def on_break?(time)
+      Calculation::OnBreak.new(self, time).result
+    end
+
     def on_holiday?(time)
       Calculation::OnHoliday.new(self, time).result
     end
-
-    alias business_hours? in_hours?
 
     def in_zone
       Time.new(time_zone)

--- a/lib/biz/time_segment.rb
+++ b/lib/biz/time_segment.rb
@@ -32,7 +32,7 @@ module Biz
     end
 
     def contains?(time)
-      (start_time..end_time).cover?(time)
+      (start_time...end_time).cover?(time)
     end
 
     def &(other)

--- a/spec/biz_spec.rb
+++ b/spec/biz_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe Biz do
     before do
       described_class.configure do |config|
         config.hours     = {sun: {'11:00' => '12:00'}}
+        config.breaks    = {Date.new(2015, 6, 1) => {'10:00' => '12:00'}}
         config.holidays  = [Date.new(2015, 12, 25)]
         config.time_zone = 'Africa/Abidjan'
       end
@@ -96,6 +97,14 @@ RSpec.describe Biz do
     describe '.business_hours?' do
       it 'delegates to the top-level schedule' do
         expect(described_class.business_hours?(Time.utc(2006, 1, 1, 11))).to eq(
+          true
+        )
+      end
+    end
+
+    describe '.on_break?' do
+      it 'delegates to the top-level schedule' do
+        expect(described_class.on_break?(Time.utc(2015, 6, 1, 11))).to eq(
           true
         )
       end

--- a/spec/calculation/active_spec.rb
+++ b/spec/calculation/active_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Biz::Calculation::Active do
 
   describe '#result' do
     context 'when the time is not contained by an interval' do
-      context 'and not on a break nor holiday' do
+      context 'and not during a break nor holiday' do
         let(:time) { Time.utc(2006, 1, 1, 6) }
 
         it 'returns false' do
@@ -19,7 +19,7 @@ RSpec.describe Biz::Calculation::Active do
         end
       end
 
-      context 'and on a break' do
+      context 'and during a break' do
         let(:time) { Time.utc(2006, 1, 3, 6) }
 
         it 'returns false' do
@@ -27,7 +27,7 @@ RSpec.describe Biz::Calculation::Active do
         end
       end
 
-      context 'and on a holiday' do
+      context 'and during a holiday' do
         let(:time) { Time.utc(2006, 1, 4, 6) }
 
         it 'returns false' do
@@ -37,7 +37,7 @@ RSpec.describe Biz::Calculation::Active do
     end
 
     context 'when the time is contained by an interval' do
-      context 'and not on a break nor holiday' do
+      context 'and not during a break nor holiday' do
         let(:time) { Time.utc(2006, 1, 2, 12) }
 
         it 'returns true' do
@@ -45,7 +45,7 @@ RSpec.describe Biz::Calculation::Active do
         end
       end
 
-      context 'and on a break' do
+      context 'and during a break' do
         let(:time) { Time.utc(2006, 1, 3, 10) }
 
         it 'returns false' do
@@ -53,7 +53,7 @@ RSpec.describe Biz::Calculation::Active do
         end
       end
 
-      context 'and on a holiday' do
+      context 'and during a holiday' do
         let(:time) { Time.utc(2006, 1, 4, 12) }
 
         it 'returns false' do

--- a/spec/calculation/on_break_spec.rb
+++ b/spec/calculation/on_break_spec.rb
@@ -1,0 +1,42 @@
+RSpec.describe Biz::Calculation::OnBreak do
+  subject(:calculation) {
+    described_class.new(
+      schedule(breaks: {Date.new(2006, 1, 4) => {'11:00' => '13:00'}}),
+      time
+    )
+  }
+
+  describe '#result' do
+    context 'when the time is at the beginning of a break' do
+      let(:time) { Time.utc(2006, 1, 4, 11) }
+
+      it 'returns true' do
+        expect(calculation.result).to eq true
+      end
+    end
+
+    context 'when the time is in the middle of a break' do
+      let(:time) { Time.utc(2006, 1, 4, 12) }
+
+      it 'returns true' do
+        expect(calculation.result).to eq true
+      end
+    end
+
+    context 'when the time is at the end of a break' do
+      let(:time) { Time.utc(2006, 1, 4, 13) }
+
+      it 'returns false' do
+        expect(calculation.result).to eq false
+      end
+    end
+
+    context 'when the time is not on a break' do
+      let(:time) { Time.utc(2006, 1, 5, 12) }
+
+      it 'returns false' do
+        expect(calculation.result).to eq false
+      end
+    end
+  end
+end

--- a/spec/calculation/on_break_spec.rb
+++ b/spec/calculation/on_break_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Biz::Calculation::OnBreak do
       end
     end
 
-    context 'when the time is not on a break' do
+    context 'when the time is not during a break' do
       let(:time) { Time.utc(2006, 1, 5, 12) }
 
       it 'returns false' do

--- a/spec/calculation/on_holiday_spec.rb
+++ b/spec/calculation/on_holiday_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Biz::Calculation::OnHoliday do
       end
     end
 
-    context 'when the time is not on a holiday' do
+    context 'when the time is not during a holiday' do
       let(:time) { Time.utc(2006, 1, 5, 12) }
 
       it 'returns false' do

--- a/spec/core_ext/time_spec.rb
+++ b/spec/core_ext/time_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Biz::CoreExt::Time do
   end
 
   describe '#on_break?' do
-    context 'when the time is on a break' do
+    context 'when the time is during a break' do
       let(:time) { time_class.utc(2006, 1, 2, 11) }
 
       it 'returns true' do
@@ -41,7 +41,7 @@ RSpec.describe Biz::CoreExt::Time do
       end
     end
 
-    context 'when the time is not on a break' do
+    context 'when the time is not during a break' do
       let(:time) { time_class.utc(2006, 1, 2, 13) }
 
       it 'returns false' do
@@ -51,7 +51,7 @@ RSpec.describe Biz::CoreExt::Time do
   end
 
   describe '#on_holiday?' do
-    context 'when the time is on a holiday' do
+    context 'when the time is during a holiday' do
       let(:time) { time_class.utc(2006, 1, 1, 12) }
 
       it 'returns true' do
@@ -59,7 +59,7 @@ RSpec.describe Biz::CoreExt::Time do
       end
     end
 
-    context 'when the time is not on a holiday' do
+    context 'when the time is not during a holiday' do
       let(:time) { time_class.utc(2006, 1, 2, 12) }
 
       it 'returns false' do

--- a/spec/core_ext/time_spec.rb
+++ b/spec/core_ext/time_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Biz::CoreExt::Time do
   before do
     Biz.configure do |config|
       config.hours     = {mon: {'09:00' => '17:00'}}
+      config.breaks    = {Date.new(2006, 1, 2) => {'10:00' => '12:00'}}
       config.holidays  = [Date.new(2006, 1, 1)]
       config.time_zone = 'Etc/UTC'
     end
@@ -15,7 +16,7 @@ RSpec.describe Biz::CoreExt::Time do
 
   describe '#business_hours?' do
     context 'when the time is within a business period' do
-      let(:time) { time_class.utc(2006, 1, 2, 10) }
+      let(:time) { time_class.utc(2006, 1, 2, 14) }
 
       it 'returns true' do
         expect(time.business_hours?).to eq true
@@ -27,6 +28,24 @@ RSpec.describe Biz::CoreExt::Time do
 
       it 'returns false' do
         expect(time.business_hours?).to eq false
+      end
+    end
+  end
+
+  describe '#on_break?' do
+    context 'when the time is on a break' do
+      let(:time) { time_class.utc(2006, 1, 2, 11) }
+
+      it 'returns true' do
+        expect(time.on_break?).to eq true
+      end
+    end
+
+    context 'when the time is not on a break' do
+      let(:time) { time_class.utc(2006, 1, 2, 13) }
+
+      it 'returns false' do
+        expect(time.on_break?).to eq false
       end
     end
   end

--- a/spec/periods/after_spec.rb
+++ b/spec/periods/after_spec.rb
@@ -268,7 +268,7 @@ RSpec.describe Biz::Periods::After do
     end
   end
 
-  context 'when a period on a holiday is encountered' do
+  context 'when a period during a holiday is encountered' do
     let(:origin) { Time.utc(2006, 1, 14) }
 
     it 'does not include that period' do
@@ -285,7 +285,7 @@ RSpec.describe Biz::Periods::After do
     end
   end
 
-  context 'when multiple periods on holidays are encountered' do
+  context 'when multiple periods during holidays are encountered' do
     let(:origin) { Time.utc(2006, 1, 14) }
 
     it 'does not include any of those periods' do

--- a/spec/periods/before_spec.rb
+++ b/spec/periods/before_spec.rb
@@ -268,7 +268,7 @@ RSpec.describe Biz::Periods::Before do
     end
   end
 
-  context 'when a period on a holiday is encountered' do
+  context 'when a period during a holiday is encountered' do
     let(:origin) { Time.utc(2006, 1, 18) }
 
     it 'does not include that period' do
@@ -285,7 +285,7 @@ RSpec.describe Biz::Periods::Before do
     end
   end
 
-  context 'when multiple periods on holidays are encountered' do
+  context 'when multiple periods during holidays are encountered' do
     let(:origin) { Time.utc(2006, 1, 20) }
 
     it 'does not include any of those periods' do

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -130,6 +130,24 @@ RSpec.describe Biz::Schedule do
     end
   end
 
+  describe '#on_break?' do
+    context 'when the time is on a break' do
+      let(:time) { Time.utc(2006, 1, 2, 11) }
+
+      it 'returns true' do
+        expect(schedule.on_break?(time)).to eq true
+      end
+    end
+
+    context 'when the time is not on a break' do
+      let(:time) { Time.utc(2006, 1, 2, 13) }
+
+      it 'returns false' do
+        expect(schedule.on_break?(time)).to eq false
+      end
+    end
+  end
+
   describe '#on_holiday?' do
     context 'when the time is on a holiday' do
       let(:time) { Time.utc(2006, 12, 25, 12) }

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe Biz::Schedule do
   end
 
   describe '#on_break?' do
-    context 'when the time is on a break' do
+    context 'when the time is during a break' do
       let(:time) { Time.utc(2006, 1, 2, 11) }
 
       it 'returns true' do
@@ -139,7 +139,7 @@ RSpec.describe Biz::Schedule do
       end
     end
 
-    context 'when the time is not on a break' do
+    context 'when the time is not during a break' do
       let(:time) { Time.utc(2006, 1, 2, 13) }
 
       it 'returns false' do
@@ -149,7 +149,7 @@ RSpec.describe Biz::Schedule do
   end
 
   describe '#on_holiday?' do
-    context 'when the time is on a holiday' do
+    context 'when the time is during a holiday' do
       let(:time) { Time.utc(2006, 12, 25, 12) }
 
       it 'returns true' do
@@ -157,7 +157,7 @@ RSpec.describe Biz::Schedule do
       end
     end
 
-    context 'when the time is not on a holiday' do
+    context 'when the time is not during a holiday' do
       let(:time) { Time.utc(2006, 12, 26, 12) }
 
       it 'returns false' do

--- a/spec/time_segment_spec.rb
+++ b/spec/time_segment_spec.rb
@@ -103,8 +103,8 @@ RSpec.describe Biz::TimeSegment do
     context 'when the time equals the end time' do
       let(:time) { end_time }
 
-      it 'returns true' do
-        expect(time_segment.contains?(time)).to eq true
+      it 'returns false' do
+        expect(time_segment.contains?(time)).to eq false
       end
     end
 


### PR DESCRIPTION
Similar to `on_holiday?` with holidays, this method can be used to determine if a provided time occurs during a break.

@zendesk/darko 