### PR TITLE
Use leading logical operators in multiline statement

### DIFF
--- a/benchmark/speed
+++ b/benchmark/speed
@@ -244,9 +244,9 @@ Benchmark.ips do |bm|
   end
 
   bm.report 'business_time' do
-    time.workday? &&
-      !Time.before_business_hours?(time) &&
-      !Time.after_business_hours?(time)
+    time.workday? \
+      && !Time.before_business_hours?(time) \
+      && !Time.after_business_hours?(time)
   end
 
   bm.report 'working_hours' do
@@ -265,9 +265,9 @@ Benchmark.ips do |bm|
   end
 
   bm.report 'business_time' do
-    time.workday? &&
-      !Time.before_business_hours?(time) &&
-      !Time.after_business_hours?(time)
+    time.workday? \
+      && !Time.before_business_hours?(time) \
+      && !Time.after_business_hours?(time)
   end
 
   bm.report 'working_hours' do

--- a/lib/biz/calculation/active.rb
+++ b/lib/biz/calculation/active.rb
@@ -8,9 +8,9 @@ module Biz
       end
 
       def result
-        schedule.intervals.any?   { |interval| interval.contains?(time) } &&
-          schedule.breaks.none?   { |break_| break_.contains?(time) } &&
-          schedule.holidays.none? { |holiday| holiday.contains?(time) }
+        schedule.intervals.any?      { |interval| interval.contains?(time) } \
+          && schedule.breaks.none?   { |break_| break_.contains?(time) } \
+          && schedule.holidays.none? { |holiday| holiday.contains?(time) }
       end
 
       protected


### PR DESCRIPTION
:smiling_imp: :rabbit:

It's unfortunate that it requires line continuations to make this possible, but I still feel like this style increases readability quite a bit over the trailing operator alternative.

If people are into this, we can do something similar in JavaScript (without the line continuation!).

For example:
```js
validSelection(target) {
  const classList = target.classList;

  return classList.contains('z-attachable-menu__item')
    || classList.contains('z-attachable-menu__item__title')
    || classList.contains('z-attachable-menu__item__value');
}
```

@zendesk/darko 