### PR TITLE
Bump to latest `rubocop`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,5 +15,5 @@ group :test do
 end
 
 group :development, :test do
-  gem 'rubocop', '~> 0.42.0', require: false
+  gem 'rubocop', '~> 0.43.0', require: false
 end

--- a/README.md
+++ b/README.md
@@ -238,8 +238,8 @@ end
 
 ## Core extensions
 
-Optional extensions to core classes (`Date`, `Fixnum`, and `Time`) are available
-for additional expressiveness:
+Optional extensions to core classes (`Date`, `Integer`, and `Time`) are
+available for additional expressiveness:
 
 ```ruby
 require 'biz/core_ext'

--- a/lib/biz/core_ext.rb
+++ b/lib/biz/core_ext.rb
@@ -4,9 +4,9 @@ module Biz
 end
 
 require 'biz/core_ext/date'
-require 'biz/core_ext/fixnum'
+require 'biz/core_ext/integer'
 require 'biz/core_ext/time'
 
-Date.class_eval   do include Biz::CoreExt::Date   end
-Fixnum.class_eval do include Biz::CoreExt::Fixnum end
-Time.class_eval   do include Biz::CoreExt::Time   end
+Date.class_eval    do include Biz::CoreExt::Date    end
+Integer.class_eval do include Biz::CoreExt::Integer end
+Time.class_eval    do include Biz::CoreExt::Time    end

--- a/lib/biz/core_ext/integer.rb
+++ b/lib/biz/core_ext/integer.rb
@@ -1,6 +1,6 @@
 module Biz
   module CoreExt
-    module Fixnum
+    module Integer
       Calculation::ForDuration.units.each do |unit|
         define_method("business_#{unit}") { Biz.time(self, unit) }
       end

--- a/lib/biz/day_time.rb
+++ b/lib/biz/day_time.rb
@@ -51,9 +51,7 @@ module Biz
     def initialize(day_second)
       @day_second = Integer(day_second)
 
-      unless VALID_SECONDS.cover?(@day_second)
-        fail ArgumentError, 'second not within a day'
-      end
+      fail ArgumentError, 'second not within a day' unless valid_second?
     end
 
     attr_reader :day_second
@@ -86,6 +84,12 @@ module Biz
       return unless other.is_a?(self.class)
 
       day_second <=> other.day_second
+    end
+
+    private
+
+    def valid_second?
+      VALID_SECONDS.cover?(day_second)
     end
 
     MIDNIGHT = from_hour(0)

--- a/spec/core_ext/integer_spec.rb
+++ b/spec/core_ext/integer_spec.rb
@@ -1,8 +1,8 @@
-require 'biz/core_ext/fixnum'
+require 'biz/core_ext/integer'
 
-RSpec.describe Biz::CoreExt::Fixnum do
-  let(:fixnum_class) {
-    Class.new(SimpleDelegator) do include Biz::CoreExt::Fixnum end
+RSpec.describe Biz::CoreExt::Integer do
+  let(:integer_class) {
+    Class.new(SimpleDelegator) do include Biz::CoreExt::Integer end
   }
 
   before do
@@ -18,7 +18,7 @@ RSpec.describe Biz::CoreExt::Fixnum do
   describe '#business_second' do
     it 'performs a for-duration calculation for the given number of seconds' do
       expect(
-        fixnum_class.new(1).business_second.after(Time.utc(2006, 1, 2, 10))
+        integer_class.new(1).business_second.after(Time.utc(2006, 1, 2, 10))
       ).to eq Time.utc(2006, 1, 2, 10, 0, 1)
     end
   end
@@ -26,7 +26,7 @@ RSpec.describe Biz::CoreExt::Fixnum do
   describe '#business_seconds' do
     it 'performs a for-duration calculation for the given number of seconds' do
       expect(
-        fixnum_class.new(10).business_seconds.after(Time.utc(2006, 1, 2, 10))
+        integer_class.new(10).business_seconds.after(Time.utc(2006, 1, 2, 10))
       ).to eq Time.utc(2006, 1, 2, 10, 0, 10)
     end
   end
@@ -34,7 +34,7 @@ RSpec.describe Biz::CoreExt::Fixnum do
   describe '#business_minute' do
     it 'performs a for-duration calculation for the given number of minutes' do
       expect(
-        fixnum_class.new(1).business_minute.after(Time.utc(2006, 1, 2, 10))
+        integer_class.new(1).business_minute.after(Time.utc(2006, 1, 2, 10))
       ).to eq Time.utc(2006, 1, 2, 10, 1)
     end
   end
@@ -42,7 +42,7 @@ RSpec.describe Biz::CoreExt::Fixnum do
   describe '#business_minutes' do
     it 'performs a for-duration calculation for the given number of minutes' do
       expect(
-        fixnum_class.new(10).business_minutes.after(Time.utc(2006, 1, 2, 10))
+        integer_class.new(10).business_minutes.after(Time.utc(2006, 1, 2, 10))
       ).to eq Time.utc(2006, 1, 2, 10, 10)
     end
   end
@@ -50,7 +50,7 @@ RSpec.describe Biz::CoreExt::Fixnum do
   describe '#business_hour' do
     it 'performs a for-duration calculation for the given number of hours' do
       expect(
-        fixnum_class.new(1).business_hour.after(Time.utc(2006, 1, 2, 10))
+        integer_class.new(1).business_hour.after(Time.utc(2006, 1, 2, 10))
       ).to eq Time.utc(2006, 1, 2, 11)
     end
   end
@@ -58,7 +58,7 @@ RSpec.describe Biz::CoreExt::Fixnum do
   describe '#business_hours' do
     it 'performs a for-duration calculation for the given number of hours' do
       expect(
-        fixnum_class.new(10).business_hours.after(Time.utc(2006, 1, 2, 10))
+        integer_class.new(10).business_hours.after(Time.utc(2006, 1, 2, 10))
       ).to eq Time.utc(2006, 1, 9, 12)
     end
   end


### PR DESCRIPTION
Diff: https://github.com/bbatsov/rubocop/compare/v0.42.0...v0.43.0

Changes:
  - Monkeypatch `Integer` instead of `Fixnum`
  - Refactor long guard clause

@zendesk/darko 