### PR TITLE
Update to latest `rubocop`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,11 +1,14 @@
 Metrics/AbcSize:
-  Max: 20
+  Enabled: false
+
+Metrics/BlockLength:
+  Enabled: false
 
 Metrics/ClassLength:
-  Max: 120
+  Enabled: false
 
 Metrics/MethodLength:
-  Max: 20
+  Enabled: false
 
 Style/AndOr:
   EnforcedStyle: conditionals

--- a/Gemfile
+++ b/Gemfile
@@ -15,5 +15,5 @@ group :test do
 end
 
 group :development, :test do
-  gem 'rubocop', '~> 0.43.0', require: false
+  gem 'rubocop', '~> 0.44.0', require: false
 end


### PR DESCRIPTION
`v0.44.x` introduces another metric cop, `Metrics/BlockLength`, which reminded me that now would be a great time to disable all of these annoying metric cops once and for all.

@zendesk/darko 