### PR TITLE
Upgrade to latest `rubocop`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,5 +15,5 @@ group :test do
 end
 
 group :development, :test do
-  gem 'rubocop', '~> 0.44.0', require: false
+  gem 'rubocop', '~> 0.45.0', require: false
 end

--- a/lib/biz/calculation/active.rb
+++ b/lib/biz/calculation/active.rb
@@ -9,7 +9,7 @@ module Biz
 
       def result
         schedule.intervals.any?      { |interval| interval.contains?(time) } \
-          && schedule.breaks.none?   { |break_| break_.contains?(time) } \
+          && schedule.breaks.none?   { |brake| brake.contains?(time) } \
           && schedule.holidays.none? { |holiday| holiday.contains?(time) }
       end
 

--- a/lib/biz/calculation/on_break.rb
+++ b/lib/biz/calculation/on_break.rb
@@ -8,7 +8,7 @@ module Biz
       end
 
       def result
-        schedule.breaks.any? { |break_| break_.contains?(time) }
+        schedule.breaks.any? { |brake| brake.contains?(time) }
       end
 
       protected


### PR DESCRIPTION
Needed to be a bit more clever about working around the `break` reserved word due to a new cop.

The solution: `brake`.

@zendesk/darko