### PR TITLE
Use the major release of `codeclimate-test-reporter`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ cache: bundler
 
 sudo: false
 
+after_success: bundle exec codeclimate-test-reporter
+
 notifications:
   email:
     on_success: never

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,8 @@ group :development do
 end
 
 group :test do
-  gem 'codeclimate-test-reporter', '~> 0.6.0', require: false
+  gem 'codeclimate-test-reporter', '~> 1.0',    require: false
+  gem 'simplecov',                 '~> 0.12.0', require: false
 end
 
 group :development, :test do

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -1,7 +1,7 @@
 if ENV['CODECLIMATE_REPO_TOKEN']
-  require 'codeclimate-test-reporter'
+  require 'simplecov'
 
-  CodeClimate::TestReporter.start
+  SimpleCov.start
 end
 
 require 'biz'


### PR DESCRIPTION
As part of the `v1.0` release, the `codeclimate-test-reporter` gem began requiring users to install and run `simplecov` themselves before sending the results to Code Climate as part of the build.

Now, `simplecov` results will be sent to Code Climate only if the build is in a green state.

@zendesk/darko 