### PR TITLE
Bump to latest `simplecov`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ end
 
 group :test do
   gem 'codeclimate-test-reporter', '~> 1.0',    require: false
-  gem 'simplecov',                 '~> 0.12.0', require: false
+  gem 'simplecov',                 '~> 0.13.0', require: false
 end
 
 group :development, :test do


### PR DESCRIPTION
Here's the [changelog](https://github.com/colszowka/simplecov/blob/master/CHANGELOG.md#0130-2017-01-25-changes).

And look, no more warnings in the build!

**Before**:
<img width="1138" alt="screen shot 2017-01-28 at 10 28 41" src="https://cloud.githubusercontent.com/assets/762635/22398848/d754ede2-e544-11e6-8d33-a03ce92a4390.png">

**After**:
<img width="839" alt="screen shot 2017-01-28 at 10 29 04" src="https://cloud.githubusercontent.com/assets/762635/22398851/dd8b3054-e544-11e6-9dbd-72a06193f4f4.png">

@zendesk/darko 