### PR TITLE
Simplify the Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,6 @@ cache: bundler
 
 after_success: bundle exec codeclimate-test-reporter
 
-notifications:
-  email:
-    on_success: never
-    on_failure: change
-
 addons:
   code_climate:
     repo_token: 23788f6358c812402884bb474c91ba819e6c096189b8ebe45d3b10b206ed4c67

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,3 @@ rvm:
 cache: bundler
 
 after_success: bundle exec codeclimate-test-reporter
-
-addons:
-  code_climate:
-    repo_token: 23788f6358c812402884bb474c91ba819e6c096189b8ebe45d3b10b206ed4c67

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ rvm:
 
 cache: bundler
 
-sudo: false
-
 after_success: bundle exec codeclimate-test-reporter
 
 notifications:


### PR DESCRIPTION
* Remove `sudo: false` config. We're defaulted to the container-based architecture without it.
* Remove the specialized Travis email notification config. I don't have a good enough reason for being a special snowflake about it.

@zendesk/darko 