### PR TITLE
Add documentation for using schedule instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,14 @@ Biz.on_break?(Time.utc(2016, 6, 3))
 Biz.on_holiday?(Time.utc(2014, 1, 1))
 ```
 
+The same methods can be called on a configured instance:
+
+```ruby
+schedule = Biz::Schedule.new
+
+schedule.in_hours?(Time.utc(2015, 1, 1, 10))
+```
+
 All returned times are in UTC.
 
 If a schedule will be configured with a large number of holidays and performance

--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ end
 Note that times must be specified in 24-hour clock format and time zones
 must be [IANA identifiers](http://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
 
+If you're operating in a threaded environment and want to use the same
+configuration across threads, save the configured schedule as a global variable:
+
+```ruby
+$biz = Biz::Schedule.new
+```
+
 ## Usage
 
 ```ruby


### PR DESCRIPTION
I've tweaked some additions to the documentation that provide more explanation about how schedule instances can be used, which were originally suggested [here](https://github.com/zendesk/biz/pull/95) and [here](https://github.com/zendesk/biz/pull/96) by @westonganger.

Closes #94.
Closes #95.
Closes #96.

@zendesk/darko 

/cc @westonganger