### PR TITLE
Exclude development dependencies in build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,6 @@ rvm:
 
 cache: bundler
 
+bundler_args: --without benchmark development
+
 after_success: bundle exec codeclimate-test-reporter

--- a/Gemfile
+++ b/Gemfile
@@ -2,13 +2,12 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :development do
+group :benchmark do
   gem 'activesupport', "#{RUBY_VERSION < '2.2' ? '<' : '>'} 5", require: false
 
-  gem 'benchmark-ips', '~> 2.0',   require: false
-  gem 'bump',          '~> 0.5.0', require: false
-  gem 'business_time',             require: false
-  gem 'working_hours',             require: false
+  gem 'benchmark-ips', '~> 2.0', require: false
+  gem 'business_time',           require: false
+  gem 'working_hours',           require: false
 end
 
 group :test do
@@ -17,5 +16,8 @@ group :test do
 end
 
 group :development, :test do
+  gem 'bump',    '~> 0.5.0',  require: false
+  gem 'rake',    '~> 12.0',   require: false
+  gem 'rspec',   '~> 3.0',    require: false
   gem 'rubocop', '~> 0.48.0', require: false
 end

--- a/biz.gemspec
+++ b/biz.gemspec
@@ -13,9 +13,6 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.2'
 
-  gem.add_runtime_dependency 'clavius', '~> 1.0'
-  gem.add_runtime_dependency 'tzinfo'
-
-  gem.add_development_dependency 'rake',  '~> 12.0'
-  gem.add_development_dependency 'rspec', '~> 3.0'
+  gem.add_dependency 'clavius', '~> 1.0'
+  gem.add_dependency 'tzinfo'
 end


### PR DESCRIPTION
Since development (and benchmarking) dependencies aren't needed to run the build, we shouldn't use resources fetching and installing them.

I've also consolidated all development dependencies into the `Gemfile`. There's no practical reason to include some development dependencies in the gemspec and not others, and it's easier to reasonable about the entire set of dependencies if they're in one place.

@zendesk/darko 