### PR TITLE
Add helper for generating periods on a date

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ Biz.time(2, :hours).after(Time.utc(2015, 12, 25, 9, 30))
 # Calculations can be performed in seconds, minutes, hours, or days
 Biz.time(1, :day).after(Time.utc(2015, 1, 8, 10))
 
+# Find the previous business time
+Biz.time(0, :hours).before(Time.utc(2016, 1, 8, 6))
+
+# Find the next business time
+Biz.time(0, :hours).after(Time.utc(2016, 1, 8, 20))
+
 # Find the amount of business time between two times
 Biz.within(Time.utc(2015, 3, 7), Time.utc(2015, 3, 14)).in_seconds
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ Biz.time(1, :day).after(Time.utc(2015, 1, 8, 10))
 # Find the amount of business time between two times
 Biz.within(Time.utc(2015, 3, 7), Time.utc(2015, 3, 14)).in_seconds
 
+# Find the start of the business day
+Biz.periods.on(Date.today).first.start_time
+
+# Find the end of the business day
+Biz.periods.on(Date.today).to_a.last.end_time
+
 # Determine if a time is in business hours
 Biz.in_hours?(Time.utc(2015, 1, 10, 9))
 

--- a/lib/biz/periods/proxy.rb
+++ b/lib/biz/periods/proxy.rb
@@ -14,6 +14,14 @@ module Biz
         Before.new(schedule, origin)
       end
 
+      def on(date)
+        schedule
+          .periods
+          .after(schedule.in_zone.on_date(date, DayTime.midnight))
+          .timeline
+          .until(schedule.in_zone.on_date(date, DayTime.endnight))
+      end
+
       protected
 
       attr_reader :schedule

--- a/spec/periods/proxy_spec.rb
+++ b/spec/periods/proxy_spec.rb
@@ -1,5 +1,16 @@
 RSpec.describe Biz::Periods::Proxy do
-  subject(:periods) { described_class.new(schedule) }
+  let(:hours) {
+    {
+      mon: {'09:00' => '17:00'},
+      tue: {'10:00' => '16:00'},
+      wed: {'09:00' => '17:00'},
+      thu: {'10:00' => '12:00', '13:00' => '17:00'},
+      fri: {'09:00' => '17:00'},
+      sat: {'11:00' => '14:30'}
+    }
+  }
+
+  subject(:periods) { described_class.new(schedule(hours: hours)) }
 
   describe '#after' do
     let(:origin) { Time.utc(2006, 1, 3) }
@@ -30,6 +41,23 @@ RSpec.describe Biz::Periods::Proxy do
         Biz::TimeSegment.new(
           Time.utc(2006, 1, 3, 10),
           Time.utc(2006, 1, 3, 16)
+        )
+      ]
+    end
+  end
+
+  describe '#on' do
+    let(:date) { Date.new(2006, 1, 5) }
+
+    it 'generates periods on the provided date' do
+      expect(periods.on(date).to_a).to eq [
+        Biz::TimeSegment.new(
+          Time.utc(2006, 1, 5, 10),
+          Time.utc(2006, 1, 5, 12)
+        ),
+        Biz::TimeSegment.new(
+          Time.utc(2006, 1, 5, 13),
+          Time.utc(2006, 1, 5, 17)
         )
       ]
     end


### PR DESCRIPTION
This makes it much more straightforward to answer common questions such as "What was the first business time today?" or "What is the last business time today?".

Further, more docs have been added to show how to calculate the previous or next business time from a given point in time, which is another common operation.

Closes #102.

@zendesk/darko 

/cc @jakcharlton