### PR TITLE
Bump to latest `rubocop`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,12 @@
+Layout/EmptyLinesAroundClassBody:
+  EnforcedStyle: empty_lines
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
+Layout/SpaceInsideHashLiteralBraces:
+  EnforcedStyle: no_space
+
 Metrics/AbcSize:
   Enabled: false
 
@@ -19,12 +28,6 @@ Style/BlockDelimiters:
 Style/Documentation:
   Enabled: false
 
-Style/EmptyLinesAroundClassBody:
-  EnforcedStyle: empty_lines
-
-Style/MultilineMethodCallIndentation:
-  EnforcedStyle: indented
-
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:
     default: '[]'
@@ -32,5 +35,5 @@ Style/PercentLiteralDelimiters:
 Style/SignalException:
   EnforcedStyle: semantic
 
-Style/SpaceInsideHashLiteralBraces:
-  EnforcedStyle: no_space
+Style/YodaCondition:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -21,5 +21,5 @@ end
 group :ci, :development do
   gem 'rake',    '~> 12.0',   require: false
   gem 'rspec',   '~> 3.0',    require: false
-  gem 'rubocop', '~> 0.48.0', require: false
+  gem 'rubocop', '~> 0.49.0', require: false
 end


### PR DESCRIPTION
- Update configuration to use a new namespace for a couple cops.
- Disable the new `Style/YodaCondition` cop. The hit to readability isn't worth the protection against the error it's trying to guard against (incorrectly performing assignment instead of an equality check).

@zendesk/darko 