### PR TITLE
Implement shifts

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Time calculations using business hours.
   - Intervals spanning the entire day.
   - Holidays.
   - Breaks (time-segment holidays).
+  - Shifts (date-based intervals).
 * Second-level calculation precision.
 * Seamless Daylight Saving Time handling.
 * Schedule intersection.
@@ -51,6 +52,11 @@ Biz.configure do |config|
     sat: {'10:00' => '14:00'}
   }
 
+  config.shifts = {
+    Date.new(2006, 1, 1) => {'09:00' => '12:00'},
+    Date.new(2006, 1, 7) => {'08:00' => '10:00', '12:00' => '14:00'}
+  }
+
   config.breaks = {
     Date.new(2006, 1, 2) => {'10:00' => '11:30'},
     Date.new(2006, 1, 3) => {'14:15' => '14:30', '15:40' => '15:50'}
@@ -61,6 +67,10 @@ Biz.configure do |config|
   config.time_zone = 'America/Los_Angeles'
 end
 ```
+
+Shifts act as exceptions to the hours configured for a particular date; that is,
+if a date is configured with both hours-based intervals and shifts, the shifts
+are in force and the intervals are disregarded.
 
 Periods occurring on holidays are disregarded. Similarly, any segment of a
 period that overlaps with a break is treated as inactive.
@@ -193,6 +203,11 @@ schedule_1 = Biz::Schedule.new do |config|
     sat: {'11:00' => '14:30'}
   }
 
+  config.shifts = {
+    Date.new(2016, 7, 1) => {'10:00' => '13:00', '15:00' => '16:00'},
+    Date.new(2016, 7, 2) => {'14:00' => '17:00'}
+  }
+
   config.breaks = {
     Date.new(2016, 6, 2) => {'09:00' => '10:30', '16:00' => '16:30'},
     Date.new(2016, 6, 3) => {'12:15' => '12:45'}
@@ -210,6 +225,11 @@ schedule_2 = Biz::Schedule.new do |config|
     tue: {'11:00' => '15:00'},
     wed: {'16:00' => '18:00'},
     thu: {'11:00' => '12:00', '13:00' => '14:00'}
+  }
+
+  config.shifts = {
+    Date.new(2016, 7, 1) => {'15:30' => '16:30'},
+    Date.new(2016, 7, 5) => {'14:00' => '18:00'}
   }
 
   config.breaks = {
@@ -230,8 +250,9 @@ schedule_1 & schedule_2
 ```
 
 The resulting schedule will be a combination of the two schedules: an
-intersection of the intervals, a union of the breaks and holidays, and the time
-zone of the first schedule.
+intersection of the intervals, a union of the breaks and holidays,
+and the time zone of the first schedule. Any configured shifts will be
+disregarded.
 
 For the above example, the resulting schedule would be equivalent to one with
 the following configuration:
@@ -243,6 +264,11 @@ Biz::Schedule.new do |config|
     tue: {'11:00' => '15:00'},
     wed: {'16:00' => '17:00'},
     thu: {'11:00' => '12:00', '13:00' => '14:00'}
+  }
+
+  config.shifts = {
+    Date.new(2016, 7, 1) => {'15:30' => '16:00'},
+    Date.new(2016, 7, 5) => {'14:00' => '16:00'}
   }
 
   config.breaks = {

--- a/lib/biz/calculation/active.rb
+++ b/lib/biz/calculation/active.rb
@@ -10,15 +10,24 @@ module Biz
       end
 
       def result
-        schedule.intervals.any?      { |interval| interval.contains?(time) } \
-          && schedule.breaks.none?   { |brake| brake.contains?(time) } \
-          && schedule.holidays.none? { |holiday| holiday.contains?(time) }
+        return in_hours? && active? if schedule.shifts.none?
+
+        schedule.periods.after(time).first.contains?(time)
       end
 
       private
 
       attr_reader :schedule,
                   :time
+
+      def in_hours?
+        schedule.intervals.any? { |interval| interval.contains?(time) }
+      end
+
+      def active?
+        schedule.holidays.none? { |holiday| holiday.contains?(time) } &&
+          schedule.breaks.none? { |brake| brake.contains?(time) }
+      end
 
     end
   end

--- a/lib/biz/periods.rb
+++ b/lib/biz/periods.rb
@@ -9,4 +9,5 @@ require 'biz/periods/abstract'
 
 require 'biz/periods/after'
 require 'biz/periods/before'
+require 'biz/periods/linear'
 require 'biz/periods/proxy'

--- a/lib/biz/periods/after.rb
+++ b/lib/biz/periods/after.rb
@@ -4,11 +4,23 @@ module Biz
   module Periods
     class After < Abstract
 
+      def initialize(schedule, origin)
+        @boundary  = TimeSegment.after(origin)
+        @intervals = schedule.intervals
+        @shifts    = schedule.shifts
+
+        super
+      end
+
       def timeline
         super.forward
       end
 
       private
+
+      def selector
+        :min_by
+      end
 
       def weeks
         Range.new(
@@ -19,14 +31,6 @@ module Biz
 
       def relevant?(period)
         origin < period.end_time
-      end
-
-      def boundary
-        @boundary ||= TimeSegment.after(origin)
-      end
-
-      def intervals
-        @intervals ||= schedule.intervals
       end
 
     end

--- a/lib/biz/periods/before.rb
+++ b/lib/biz/periods/before.rb
@@ -4,11 +4,23 @@ module Biz
   module Periods
     class Before < Abstract
 
+      def initialize(schedule, origin)
+        @boundary  = TimeSegment.before(origin)
+        @intervals = schedule.intervals.reverse
+        @shifts    = schedule.shifts.reverse
+
+        super
+      end
+
       def timeline
         super.backward
       end
 
       private
+
+      def selector
+        :max_by
+      end
 
       def weeks
         Week
@@ -22,14 +34,6 @@ module Biz
 
       def active_periods(*)
         super.reverse
-      end
-
-      def boundary
-        @boundary ||= TimeSegment.before(origin)
-      end
-
-      def intervals
-        @intervals ||= schedule.intervals.reverse
       end
 
     end

--- a/lib/biz/periods/linear.rb
+++ b/lib/biz/periods/linear.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Biz
+  module Periods
+    class Linear < SimpleDelegator
+
+      def initialize(periods, shifts, selector)
+        @periods   = periods.to_enum
+        @shifts    = shifts.to_enum
+        @selector  = selector
+        @sequences = [@periods, @shifts]
+
+        super(linear_periods)
+      end
+
+      private
+
+      attr_reader :periods,
+                  :shifts,
+                  :selector,
+                  :sequences
+
+      def linear_periods
+        Enumerator.new do |yielder|
+          loop do
+            periods.next and next if periods.peek.date == shifts.peek.date
+
+            yielder << begin
+              sequences
+                .public_send(selector) { |sequence| sequence.peek.date }
+                .next
+            end
+          end
+
+          loop do yielder << periods.next end
+        end
+      end
+
+    end
+  end
+end

--- a/lib/biz/schedule.rb
+++ b/lib/biz/schedule.rb
@@ -11,6 +11,7 @@ module Biz
 
     delegate %i[
       intervals
+      shifts
       breaks
       holidays
       time_zone

--- a/lib/biz/time_segment.rb
+++ b/lib/biz/time_segment.rb
@@ -16,10 +16,12 @@ module Biz
     def initialize(start_time, end_time)
       @start_time = start_time
       @end_time   = end_time
+      @date       = start_time.to_date
     end
 
     attr_reader :start_time,
-                :end_time
+                :end_time,
+                :date
 
     def duration
       Duration.new(end_time - start_time)

--- a/spec/calculation/active_spec.rb
+++ b/spec/calculation/active_spec.rb
@@ -4,16 +4,24 @@ RSpec.describe Biz::Calculation::Active do
   subject(:calculation) {
     described_class.new(
       schedule(
-        breaks:   {Date.new(2006, 1, 3) => {'05:30' => '11:00'}},
-        holidays: [Date.new(2006, 1, 4)]
+        shifts: {
+          Date.new(2006, 1, 7)  => {'09:00' => '11:00'},
+          Date.new(2006, 1, 10) => {'09:00' => '11:00'},
+          Date.new(2006, 1, 11) => {'09:00' => '11:00'}
+        },
+        breaks: {
+          Date.new(2006, 1, 3)  => {'05:30' => '11:00'},
+          Date.new(2006, 1, 10) => {'05:30' => '11:00'}
+        },
+        holidays: [Date.new(2006, 1, 4), Date.new(2006, 1, 11)]
       ),
       time
     )
   }
 
   describe '#result' do
-    context 'when the time is not contained by an interval' do
-      context 'and not during a break nor holiday' do
+    context 'when the time is contained neither by an interval nor a shift' do
+      context 'and during neither a break nor a holiday' do
         let(:time) { Time.utc(2006, 1, 1, 6) }
 
         it 'returns false' do
@@ -39,7 +47,7 @@ RSpec.describe Biz::Calculation::Active do
     end
 
     context 'when the time is contained by an interval' do
-      context 'and not during a break nor holiday' do
+      context 'and during neither a break nor a holiday' do
         let(:time) { Time.utc(2006, 1, 2, 12) }
 
         it 'returns true' do
@@ -57,6 +65,40 @@ RSpec.describe Biz::Calculation::Active do
 
       context 'and during a holiday' do
         let(:time) { Time.utc(2006, 1, 4, 12) }
+
+        it 'returns false' do
+          expect(calculation.result).to eq false
+        end
+      end
+
+      context 'on a date with a shift' do
+        let(:time) { Time.utc(2006, 1, 7, 12) }
+
+        it 'returns false' do
+          expect(calculation.result).to eq false
+        end
+      end
+    end
+
+    context 'when the time is contained by a shift' do
+      context 'and during neither a break nor a holiday' do
+        let(:time) { Time.utc(2006, 1, 7, 10) }
+
+        it 'returns true' do
+          expect(calculation.result).to eq true
+        end
+      end
+
+      context 'and during a break' do
+        let(:time) { Time.utc(2006, 1, 10, 10) }
+
+        it 'returns false' do
+          expect(calculation.result).to eq false
+        end
+      end
+
+      context 'and during a holiday' do
+        let(:time) { Time.utc(2006, 1, 11, 12) }
 
         it 'returns false' do
           expect(calculation.result).to eq false

--- a/spec/periods/after_spec.rb
+++ b/spec/periods/after_spec.rb
@@ -12,6 +12,14 @@ RSpec.describe Biz::Periods::After do
     }
   }
 
+  let(:shifts) {
+    {
+      Date.new(2005, 12, 31) => {'10:00' => '14:00'},
+      Date.new(2006, 1, 4)   => {'08:00' => '12:00'},
+      Date.new(2006, 1, 6)   => {'09:00' => '10:00'}
+    }
+  }
+
   let(:breaks)    { {} }
   let(:holidays)  { [Date.new(2006, 1, 16), Date.new(2006, 1, 18)] }
   let(:time_zone) { 'Etc/UTC' }
@@ -21,6 +29,7 @@ RSpec.describe Biz::Periods::After do
     described_class.new(
       schedule(
         hours:     hours,
+        shifts:    shifts,
         breaks:    breaks,
         holidays:  holidays,
         time_zone: time_zone
@@ -43,8 +52,8 @@ RSpec.describe Biz::Periods::After do
           Time.utc(2006, 1, 3, 16)
         ),
         Biz::TimeSegment.new(
-          Time.utc(2006, 1, 4, 9),
-          Time.utc(2006, 1, 4, 17)
+          Time.utc(2006, 1, 4, 8),
+          Time.utc(2006, 1, 4, 12)
         ),
         Biz::TimeSegment.new(
           Time.utc(2006, 1, 5, 10),
@@ -52,7 +61,7 @@ RSpec.describe Biz::Periods::After do
         ),
         Biz::TimeSegment.new(
           Time.utc(2006, 1, 6, 9),
-          Time.utc(2006, 1, 6, 17)
+          Time.utc(2006, 1, 6, 10)
         ),
         Biz::TimeSegment.new(
           Time.utc(2006, 1, 7, 11),
@@ -76,16 +85,15 @@ RSpec.describe Biz::Periods::After do
           Time.utc(2006, 1, 3, 16)
         ),
         Biz::TimeSegment.new(
-          Time.utc(2006, 1, 4, 9),
-          Time.utc(2006, 1, 4, 17)
-        ),
-        Biz::TimeSegment.new(
+          Time.utc(2006, 1, 4, 8),
+          Time.utc(2006, 1, 4, 12)
+        ), Biz::TimeSegment.new(
           Time.utc(2006, 1, 5, 10),
           Time.utc(2006, 1, 5, 16)
         ),
         Biz::TimeSegment.new(
           Time.utc(2006, 1, 6, 9),
-          Time.utc(2006, 1, 6, 17)
+          Time.utc(2006, 1, 6, 10)
         ),
         Biz::TimeSegment.new(
           Time.utc(2006, 1, 7, 11),

--- a/spec/periods/before_spec.rb
+++ b/spec/periods/before_spec.rb
@@ -12,6 +12,14 @@ RSpec.describe Biz::Periods::Before do
     }
   }
 
+  let(:shifts) {
+    {
+      Date.new(2006, 1, 4)  => {'09:00' => '10:00'},
+      Date.new(2006, 1, 5)  => {'08:00' => '12:00'},
+      Date.new(2006, 1, 31) => {'06:00' => '20:00'}
+    }
+  }
+
   let(:breaks)    { {} }
   let(:holidays)  { [Date.new(2006, 1, 16), Date.new(2006, 1, 18)] }
   let(:time_zone) { 'Etc/UTC' }
@@ -21,6 +29,7 @@ RSpec.describe Biz::Periods::Before do
     described_class.new(
       schedule(
         hours:     hours,
+        shifts:    shifts,
         breaks:    breaks,
         holidays:  holidays,
         time_zone: time_zone
@@ -43,12 +52,12 @@ RSpec.describe Biz::Periods::Before do
           Time.utc(2006, 1, 6, 17)
         ),
         Biz::TimeSegment.new(
-          Time.utc(2006, 1, 5, 10),
-          Time.utc(2006, 1, 5, 16)
+          Time.utc(2006, 1, 5, 8),
+          Time.utc(2006, 1, 5, 12)
         ),
         Biz::TimeSegment.new(
           Time.utc(2006, 1, 4, 9),
-          Time.utc(2006, 1, 4, 17)
+          Time.utc(2006, 1, 4, 10)
         ),
         Biz::TimeSegment.new(
           Time.utc(2006, 1, 3, 10),
@@ -100,12 +109,12 @@ RSpec.describe Biz::Periods::Before do
           Time.utc(2006, 1, 6, 17)
         ),
         Biz::TimeSegment.new(
-          Time.utc(2006, 1, 5, 10),
-          Time.utc(2006, 1, 5, 16)
+          Time.utc(2006, 1, 5, 8),
+          Time.utc(2006, 1, 5, 12)
         ),
         Biz::TimeSegment.new(
           Time.utc(2006, 1, 4, 9),
-          Time.utc(2006, 1, 4, 17)
+          Time.utc(2006, 1, 4, 10)
         ),
         Biz::TimeSegment.new(
           Time.utc(2006, 1, 3, 10),

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -39,6 +39,12 @@ RSpec.describe Biz::Schedule do
     end
   end
 
+  describe '#shifts' do
+    it 'delegates to the configuration' do
+      expect(schedule.shifts).to eq Biz::Configuration.new(&config).shifts
+    end
+  end
+
   describe '#breaks' do
     it 'delegates to the configuration' do
       expect(schedule.breaks).to eq Biz::Configuration.new(&config).breaks

--- a/spec/support/time.rb
+++ b/spec/support/time.rb
@@ -39,6 +39,7 @@ module Biz
               sat: {'11:00' => '14:30'}
             )
 
+            config.shifts    = args.fetch(:shifts, {})
             config.breaks    = args.fetch(:breaks, {})
             config.holidays  = args.fetch(:holidays, [])
             config.time_zone = args.fetch(:time_zone, 'Etc/UTC')

--- a/spec/time_segment_spec.rb
+++ b/spec/time_segment_spec.rb
@@ -42,6 +42,12 @@ RSpec.describe Biz::TimeSegment do
     end
   end
 
+  describe '#date' do
+    it 'returns the date corresponding with the start time' do
+      expect(time_segment.date).to eq Date.new(2006, 1, 8)
+    end
+  end
+
   describe '#endpoints' do
     it 'returns the endpoints' do
       expect(time_segment.endpoints).to eq [


### PR DESCRIPTION
Shifts are date-based exceptions to configured weekly hours.

This has been a frequent feature request (See: https://github.com/zendesk/biz/issues/5, https://github.com/zendesk/biz/issues/103, https://github.com/zendesk/biz/issues/122).

For a given day in which shifts are configured, intervals that land on that day will be ignored.

For example, given the following schedule:

```ruby
Biz::Schedule.new do |config|
  config.hours = {
    mon: {'09:00' => '17:00'},
    tue: {'09:00' => '17:00'},
    wed: {'09:00' => '17:00'},
    thu: {'09:00' => '17:00'},
    fri: {'09:00' => '17:00'}
  }

  config.shifts = {
    Date.new(2017, 7, 10) => {'10:00' => '12:00', '13:00' => '16:00'}
  }
end
```

On July 10, 2017, which is a Monday, the base configuration of one active period from 9am to 5pm will be ignored and two periods of 10am-12pm and 1pm-4pm will be returned on that date instead.

I decided to retain the optimized version of the `in_hours?` check for all schedules that do not have shifts configured to maintain performance parity with competing libraries. In cases where shifts are configured, the logic drops down to interacting with periods directly in order to generate a result, which is many multiples slower, but given that writing an optimized form that included shifts would have turned into a mess, I think it's a reasonable choice for now.

I added an additional spec to prove the optimized version of `in_hours?` doesn't work when shifts are configured to guard against future ill-advised attempts to use that path exclusively.

**Before merging**:

- [x] (Decide not to) support schedule intersection
- [x] Write specs
- [x] Write documentation

Closes #103.
Closes #122.

@zendesk/darko 