### PR TITLE
Bump dependencies

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,6 +34,3 @@ Style/PercentLiteralDelimiters:
 
 Style/SignalException:
   EnforcedStyle: semantic
-
-Style/YodaCondition:
-  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 
 rvm:
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
+  - 2.2.8
+  - 2.3.5
+  - 2.4.2
 
 cache: bundler
 

--- a/Gemfile
+++ b/Gemfile
@@ -21,5 +21,5 @@ end
 group :ci, :development do
   gem 'rake',    '~> 12.0',   require: false
   gem 'rspec',   '~> 3.0',    require: false
-  gem 'rubocop', '~> 0.49.0', require: false
+  gem 'rubocop', '~> 0.50.0', require: false
 end


### PR DESCRIPTION
See the individual commits for details.

In short, use the latest Ruby VMs and `rubocop`.

@zendesk/darko @joshlam 