### PR TITLE
Calibrate method privacy

### DIFF
--- a/lib/biz/calculation/active.rb
+++ b/lib/biz/calculation/active.rb
@@ -15,7 +15,7 @@ module Biz
           && schedule.holidays.none? { |holiday| holiday.contains?(time) }
       end
 
-      protected
+      private
 
       attr_reader :schedule,
                   :time

--- a/lib/biz/calculation/for_duration.rb
+++ b/lib/biz/calculation/for_duration.rb
@@ -91,12 +91,10 @@ module Biz
         fail ArgumentError, 'negative scalar' if @scalar.negative?
       end
 
-      protected
+      private
 
       attr_reader :schedule,
                   :scalar
-
-      private
 
       def unit
         self.class.unit

--- a/lib/biz/calculation/on_break.rb
+++ b/lib/biz/calculation/on_break.rb
@@ -13,7 +13,7 @@ module Biz
         schedule.breaks.any? { |brake| brake.contains?(time) }
       end
 
-      protected
+      private
 
       attr_reader :schedule,
                   :time

--- a/lib/biz/calculation/on_holiday.rb
+++ b/lib/biz/calculation/on_holiday.rb
@@ -13,7 +13,7 @@ module Biz
         schedule.holidays.any? { |holiday| holiday.contains?(time) }
       end
 
-      protected
+      private
 
       attr_reader :schedule,
                   :time

--- a/lib/biz/day_of_week.rb
+++ b/lib/biz/day_of_week.rb
@@ -53,6 +53,8 @@ module Biz
       wday == other_wday
     end
 
+    private
+
     def <=>(other)
       return unless other.is_a?(self.class)
 

--- a/lib/biz/day_time.rb
+++ b/lib/biz/day_time.rb
@@ -82,16 +82,16 @@ module Biz
       format(Timestamp::FORMAT, hour, minute)
     end
 
-    def <=>(other)
-      return unless other.is_a?(self.class)
-
-      day_second <=> other.day_second
-    end
-
     private
 
     def valid_second?
       VALID_SECONDS.cover?(day_second)
+    end
+
+    def <=>(other)
+      return unless other.is_a?(self.class)
+
+      day_second <=> other.day_second
     end
 
     MIDNIGHT = from_hour(0)

--- a/lib/biz/duration.rb
+++ b/lib/biz/duration.rb
@@ -59,15 +59,17 @@ module Biz
       self.class.new(seconds.abs)
     end
 
+    protected
+
+    attr_reader :seconds
+
+    private
+
     def <=>(other)
       return unless other.is_a?(self.class)
 
       seconds <=> other.seconds
     end
-
-    protected
-
-    attr_reader :seconds
 
   end
 end

--- a/lib/biz/holiday.rb
+++ b/lib/biz/holiday.rb
@@ -23,12 +23,6 @@ module Biz
       end
     end
 
-    def <=>(other)
-      return unless other.is_a?(self.class)
-
-      [date, time_zone] <=> [other.date, other.time_zone]
-    end
-
     protected
 
     attr_reader :date,
@@ -38,6 +32,14 @@ module Biz
 
     def to_date
       date
+    end
+
+    private
+
+    def <=>(other)
+      return unless other.is_a?(self.class)
+
+      [date, time_zone] <=> [other.date, other.time_zone]
     end
 
   end

--- a/lib/biz/interval.rb
+++ b/lib/biz/interval.rb
@@ -56,6 +56,8 @@ module Biz
       self.class.new(lower_bound, [lower_bound, upper_bound].max, time_zone)
     end
 
+    private
+
     def <=>(other)
       return unless other.is_a?(self.class)
 

--- a/lib/biz/periods/abstract.rb
+++ b/lib/biz/periods/abstract.rb
@@ -15,12 +15,10 @@ module Biz
         Timeline::Proxy.new(self)
       end
 
-      protected
+      private
 
       attr_reader :schedule,
                   :origin
-
-      private
 
       def periods
         weeks

--- a/lib/biz/periods/proxy.rb
+++ b/lib/biz/periods/proxy.rb
@@ -24,7 +24,7 @@ module Biz
           .until(schedule.in_zone.on_date(date, DayTime.endnight))
       end
 
-      protected
+      private
 
       attr_reader :schedule
 

--- a/lib/biz/time.rb
+++ b/lib/biz/time.rb
@@ -96,7 +96,7 @@ module Biz
       on_date(week.start_date + week_time.wday, week_time.day_time)
     end
 
-    protected
+    private
 
     attr_reader :time_zone
 

--- a/lib/biz/time_segment.rb
+++ b/lib/biz/time_segment.rb
@@ -51,6 +51,8 @@ module Biz
       ].reject(&:empty?).map { |potential| self & potential }
     end
 
+    private
+
     def <=>(other)
       return unless other.is_a?(self.class)
 

--- a/lib/biz/timeline/abstract.rb
+++ b/lib/biz/timeline/abstract.rb
@@ -36,7 +36,7 @@ module Biz
           end
       end
 
-      protected
+      private
 
       attr_reader :periods
 

--- a/lib/biz/timeline/proxy.rb
+++ b/lib/biz/timeline/proxy.rb
@@ -16,7 +16,7 @@ module Biz
         Backward.new(periods)
       end
 
-      protected
+      private
 
       attr_reader :periods
 

--- a/lib/biz/validation.rb
+++ b/lib/biz/validation.rb
@@ -17,7 +17,7 @@ module Biz
       self
     end
 
-    protected
+    private
 
     attr_reader :raw
 
@@ -32,7 +32,7 @@ module Biz
         fail Error::Configuration, message unless condition.call(raw)
       end
 
-      protected
+      private
 
       attr_reader :message,
                   :condition

--- a/lib/biz/week.rb
+++ b/lib/biz/week.rb
@@ -43,15 +43,17 @@ module Biz
       self.class.new(week + other.week)
     end
 
+    protected
+
+    attr_reader :week
+
+    private
+
     def <=>(other)
       return unless other.is_a?(self.class)
 
       week <=> other.week
     end
-
-    protected
-
-    attr_reader :week
 
   end
 end

--- a/lib/biz/week_time/abstract.rb
+++ b/lib/biz/week_time/abstract.rb
@@ -35,15 +35,17 @@ module Biz
         timestamp
       ] => :day_time
 
+      protected
+
+      attr_reader :week_minute
+
+      private
+
       def <=>(other)
         return unless other.is_a?(WeekTime::Abstract)
 
         week_minute <=> other.week_minute
       end
-
-      protected
-
-      attr_reader :week_minute
 
     end
   end


### PR DESCRIPTION
As of Ruby 2.3, use of private `attr_reader`s no longer emits warnings.

All `attr_reader`s that can be private are now private. In addition, all `<=>` methods have been made private since it's not necessary for them to be protected.

@alex-stone 