### PR TITLE
Rename `Gemfile` to `gems.rb`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 *.gem
 .bundle
-Gemfile.lock
+gems.locked
 pkg
 bin/
 coverage/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,9 +31,5 @@ Style/BlockDelimiters:
 Style/Documentation:
   Enabled: false
 
-Style/PercentLiteralDelimiters:
-  PreferredDelimiters:
-    default: '[]'
-
 Style/SignalException:
   EnforcedStyle: semantic

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ rvm:
 
 cache: bundler
 
+gemfile: gems.rb
+
 bundler_args: --without benchmark development
 
 before_install: gem update --system

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,4 @@ gemfile: gems.rb
 
 bundler_args: --without benchmark development
 
-before_install: gem update --system
-
 after_success: bundle exec codeclimate-test-reporter

--- a/gems.rb
+++ b/gems.rb
@@ -17,7 +17,7 @@ end
 
 group :development do
   gem 'bump',    '~> 0.6.0', require: false
-  gem 'bundler', '~> 1.0',   require: false
+  gem 'bundler', '~> 1.8',   require: false
 end
 
 group :ci, :development do


### PR DESCRIPTION
In v2.0, Bundler will move from `Gemfile` (and `Gemfile.lock`) to `gems.rb` (and `gems.locked`) as the default filenames for those files. In the meantime, the new filenames are already supported by recent releases of Bundler.

It's time to move boldly into the future.

Note that Bundler began acknowledging the new gem file format as of v1.8, hence the `bundler` version requirement bump.

See: https://depfu.com/blog/2017/09/06/gemfiles-new-clothes