### PR TITLE
Use new Code Climate test reporter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,9 @@ gemfile: gems.rb
 
 bundler_args: --without benchmark development
 
-after_success: bundle exec codeclimate-test-reporter
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
+
+after_success: ./cc-test-reporter after-build -t simplecov --exit-code $TRAVIS_TEST_RESULT

--- a/gems.rb
+++ b/gems.rb
@@ -22,5 +22,5 @@ end
 group :ci, :development do
   gem 'rake',    '~> 12.0',   require: false
   gem 'rspec',   '~> 3.0',    require: false
-  gem 'rubocop', '~> 0.58.0', require: false
+  gem 'rubocop', '~> 0.59.0', require: false
 end

--- a/gems.rb
+++ b/gems.rb
@@ -11,8 +11,7 @@ group :benchmark do
 end
 
 group :ci do
-  gem 'codeclimate-test-reporter', '~> 1.0',    require: false
-  gem 'simplecov',                 '~> 0.16.0', require: false
+  gem 'simplecov', '~> 0.16.0', require: false
 end
 
 group :development do

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-if ENV['CODECLIMATE_REPO_TOKEN']
+if ENV['CI']
   require 'simplecov'
 
   SimpleCov.start


### PR DESCRIPTION
The old language-specific test reporter has been deprecated in favor of a new one that comes in binary form.

See: codeclimate/ruby-test-reporter#195

This also bumps to the latest `rubocop` (without requiring any changes).