### PR TITLE
Upgrade to `benchmark-ipsa` for memory stats

### DIFF
--- a/benchmark/performance
+++ b/benchmark/performance
@@ -4,7 +4,7 @@
 
 require 'bundler/setup'
 
-require 'benchmark/ips'
+require 'benchmark/ipsa'
 
 require 'biz'
 require 'business_time'
@@ -64,7 +64,7 @@ WorkingHours::Config.tap do |config|
 end
 
 benchmark 'Return time one business hour after origin'
-Benchmark.ips do |bm|
+Benchmark.ipsa do |bm|
   origin = Time.utc(2006, 1, 2, 9, 30)
 
   bm.report 'biz' do
@@ -83,7 +83,7 @@ Benchmark.ips do |bm|
 end
 
 benchmark 'Return time 100 business hours after origin'
-Benchmark.ips do |bm|
+Benchmark.ipsa do |bm|
   origin = Time.utc(2006, 1, 2, 9, 30)
 
   bm.report 'biz' do
@@ -102,7 +102,7 @@ Benchmark.ips do |bm|
 end
 
 benchmark 'Return time 10,000 business hours after origin'
-Benchmark.ips do |bm|
+Benchmark.ipsa do |bm|
   origin = Time.utc(2006, 1, 2, 9, 30)
 
   bm.report 'biz' do
@@ -121,7 +121,7 @@ Benchmark.ips do |bm|
 end
 
 benchmark 'Return time one business hour before origin'
-Benchmark.ips do |bm|
+Benchmark.ipsa do |bm|
   origin = Time.utc(2006, 1, 2, 9, 30)
 
   bm.report 'biz' do
@@ -140,7 +140,7 @@ Benchmark.ips do |bm|
 end
 
 benchmark 'Return time 100 business hours before origin'
-Benchmark.ips do |bm|
+Benchmark.ipsa do |bm|
   origin = Time.utc(2006, 1, 2, 9, 30)
 
   bm.report 'biz' do
@@ -159,7 +159,7 @@ Benchmark.ips do |bm|
 end
 
 benchmark 'Return time 10,000 business hours before origin'
-Benchmark.ips do |bm|
+Benchmark.ipsa do |bm|
   origin = Time.utc(2006, 1, 2, 9, 30)
 
   bm.report 'biz' do
@@ -178,7 +178,7 @@ Benchmark.ips do |bm|
 end
 
 benchmark 'Return amount of business time between two times one hour apart'
-Benchmark.ips do |bm|
+Benchmark.ipsa do |bm|
   origin   = Time.utc(2006, 1, 2, 9)
   terminus = Time.utc(2006, 1, 2, 10)
 
@@ -198,7 +198,7 @@ Benchmark.ips do |bm|
 end
 
 benchmark 'Return amount of business time between two times one week apart'
-Benchmark.ips do |bm|
+Benchmark.ipsa do |bm|
   origin   = Time.utc(2006, 1, 2, 9)
   terminus = Time.utc(2006, 1, 9, 9)
 
@@ -218,7 +218,7 @@ Benchmark.ips do |bm|
 end
 
 benchmark 'Return amount of business time between two times one year apart'
-Benchmark.ips do |bm|
+Benchmark.ipsa do |bm|
   origin   = Time.utc(2006, 1, 2, 9)
   terminus = Time.utc(2006, 7, 2, 9)
 
@@ -238,7 +238,7 @@ Benchmark.ips do |bm|
 end
 
 benchmark 'Check if an in-business-hours time is in business hours'
-Benchmark.ips do |bm|
+Benchmark.ipsa do |bm|
   time = Time.utc(2006, 1, 4, 12)
 
   bm.report 'biz' do
@@ -259,7 +259,7 @@ Benchmark.ips do |bm|
 end
 
 benchmark 'Check if an out-of-business-hours time is in business hours'
-Benchmark.ips do |bm|
+Benchmark.ipsa do |bm|
   time = Time.utc(2006, 1, 4, 6)
 
   bm.report 'biz' do

--- a/gems.rb
+++ b/gems.rb
@@ -5,9 +5,9 @@ source 'https://rubygems.org'
 gemspec
 
 group :benchmark do
-  gem 'benchmark-ips', '~> 2.0',   require: false
-  gem 'business_time', '~> 0.9.0', require: false
-  gem 'working_hours', '~> 1.0',   require: false
+  gem 'benchmark-ipsa', '~> 0.2.0', require: false
+  gem 'business_time',  '~> 0.9.0', require: false
+  gem 'working_hours',  '~> 1.0',   require: false
 end
 
 group :ci do


### PR DESCRIPTION
We can essentially drop in `benchmark-ipsa` to start getting memory statistics in our benchmarks. Seems good.

Example:
```
Benchmark: Return time 100 business hours after origin
Allocations -------------------------------------
                 biz  1286/190  alloc/ret        7/1  strings/ret
       business_time    3763/3  alloc/ret        7/0  strings/ret
       working_hours   1151/10  alloc/ret        2/0  strings/ret
Warming up --------------------------------------
                 biz    99.000  i/100ms
       business_time    43.000  i/100ms
       working_hours    95.000  i/100ms
Calculating -------------------------------------
                 biz      1.006k (± 3.2%) i/s -      5.049k
       business_time    440.021  (± 2.5%) i/s -      2.236k
       working_hours    965.186  (± 2.3%) i/s -      4.845k

Comparison:
                 biz:     1005.9 i/s
       working_hours:      965.2 i/s - same-ish: difference falls within error
       business_time:      440.0 i/s - 2.29x slower
```

/cc @alex-stone