### PR TITLE
Bump dependencies

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,11 @@
 AllCops:
   TargetRubyVersion: 2.3
 
+Layout/AlignHash:
+  EnforcedHashRocketStyle: table
+  EnforcedColonStyle: table
+  EnforcedLastArgumentHashStyle: ignore_implicit
+
 Layout/EmptyLinesAroundClassBody:
   EnforcedStyle: empty_lines
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
+  - 2.6
   - jruby-9.1
   - jruby-head
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 
 rvm:
-  - 2.3.7
-  - 2.4.4
-  - 2.5.1
+  - 2.3
+  - 2.4
+  - 2.5
   - jruby-9.1
   - jruby-head
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ gemfile: gems.rb
 
 bundler_args: --without benchmark development
 
+before_install: gem install bundler
+
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Add support for Ruby 2.6
+
 ## [v1.8.1] (October 30, 2018)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ To open a console with the gem and sample schedule loaded:
 
 ## Copyright and license
 
-Copyright 2015-18 Zendesk
+Copyright 2015-19 Zendesk
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this gem except in compliance with the License.

--- a/gems.rb
+++ b/gems.rb
@@ -22,5 +22,5 @@ end
 group :ci, :development do
   gem 'rake',    '~> 12.0',   require: false
   gem 'rspec',   '~> 3.0',    require: false
-  gem 'rubocop', '~> 0.59.0', require: false
+  gem 'rubocop', '~> 0.62.0', require: false
 end

--- a/gems.rb
+++ b/gems.rb
@@ -16,7 +16,7 @@ end
 
 group :development do
   gem 'bump',    '~> 0.7.0', require: false
-  gem 'bundler', '~> 1.8',   require: false
+  gem 'bundler', '~> 2.0',   require: false
 end
 
 group :ci, :development do

--- a/gems.rb
+++ b/gems.rb
@@ -15,7 +15,7 @@ group :ci do
 end
 
 group :development do
-  gem 'bump',    '~> 0.6.0', require: false
+  gem 'bump',    '~> 0.7.0', require: false
   gem 'bundler', '~> 1.8',   require: false
 end
 

--- a/lib/biz/day_time.rb
+++ b/lib/biz/day_time.rb
@@ -7,7 +7,8 @@ module Biz
 
     module Timestamp
       FORMAT  = '%02d:%02d'
-      PATTERN = /\A(?<hour>\d{2}):(?<minute>\d{2})(:?(?<second>\d{2}))?\Z/
+      PATTERN =
+        /\A(?<hour>\d{2}):(?<minute>\d{2})(:?(?<second>\d{2}))?\Z/.freeze
     end
 
     include Comparable


### PR DESCRIPTION
This adds explicit support for Ruby 2.6 (by running the build against it) and bumps all dependencies to the latest.