### PR TITLE
Treat endpoints consistently in calculations

### DIFF
--- a/lib/biz/calculation/for_duration.rb
+++ b/lib/biz/calculation/for_duration.rb
@@ -25,14 +25,10 @@ module Biz
       def self.time_class
         Class.new(self) do
           def before(time)
-            return moment_before(time) if scalar.zero?
-
             advanced_periods(:before, time).last.start_time
           end
 
           def after(time)
-            return moment_after(time) if scalar.zero?
-
             advanced_periods(:after, time).last.end_time
           end
 
@@ -52,31 +48,34 @@ module Biz
       def self.day_class
         Class.new(self) do
           def before(time)
-            return moment_before(time) if scalar.zero?
-
             periods(:before, time).first.end_time
           end
 
           def after(time)
-            return moment_after(time) if scalar.zero?
-
             periods(:after, time).first.start_time
           end
 
           private
 
           def periods(direction, time)
-            schedule.periods.public_send(
-              direction,
-              advanced_time(direction, schedule.in_zone.local(time))
-            )
+            schedule
+              .periods
+              .public_send(
+                direction,
+                advanced_time(direction, schedule.in_zone.local(time))
+              )
           end
 
           def advanced_time(direction, time)
-            schedule.in_zone.on_date(
-              schedule.dates.days(scalar).public_send(direction, time),
-              DayTime.from_time(time)
-            )
+            schedule
+              .in_zone
+              .on_date(
+                schedule
+                  .dates
+                  .days(scalar)
+                  .public_send(direction, time.to_date),
+                DayTime.from_time(time)
+              )
           end
         end
       end
@@ -98,14 +97,6 @@ module Biz
 
       def unit
         self.class.unit
-      end
-
-      def moment_before(time)
-        schedule.periods.before(time).first.end_time
-      end
-
-      def moment_after(time)
-        schedule.periods.after(time).first.start_time
       end
 
       [

--- a/lib/biz/periods/abstract.rb
+++ b/lib/biz/periods/abstract.rb
@@ -26,11 +26,10 @@ module Biz
       def periods
         Linear.new(week_periods, shifts, selector)
           .lazy
-          .select   { |period| relevant?(period) }
-          .map      { |period| period & boundary }
+          .map { |period| period & boundary }
+          .reject(&:disjoint?)
           .flat_map { |period| active_periods(period) }
           .reject   { |period| on_holiday?(period) }
-          .reject(&:empty?)
       end
 
       def week_periods

--- a/lib/biz/periods/after.rb
+++ b/lib/biz/periods/after.rb
@@ -29,10 +29,6 @@ module Biz
         )
       end
 
-      def relevant?(period)
-        origin < period.end_time
-      end
-
     end
   end
 end

--- a/lib/biz/periods/before.rb
+++ b/lib/biz/periods/before.rb
@@ -28,10 +28,6 @@ module Biz
           .downto(Week.since_epoch(Time.big_bang))
       end
 
-      def relevant?(period)
-        origin > period.start_time
-      end
-
       def active_periods(*)
         super.reverse
       end

--- a/lib/biz/time_segment.rb
+++ b/lib/biz/time_segment.rb
@@ -24,7 +24,7 @@ module Biz
                 :date
 
     def duration
-      Duration.new(end_time - start_time)
+      Duration.new([end_time - start_time, 0].max)
     end
 
     def endpoints
@@ -32,7 +32,11 @@ module Biz
     end
 
     def empty?
-      start_time >= end_time
+      start_time == end_time
+    end
+
+    def disjoint?
+      start_time > end_time
     end
 
     def contains?(time)
@@ -40,17 +44,17 @@ module Biz
     end
 
     def &(other)
-      lower_bound = [self, other].map(&:start_time).max
-      upper_bound = [self, other].map(&:end_time).min
-
-      self.class.new(lower_bound, [lower_bound, upper_bound].max)
+      self.class.new(
+        [self, other].map(&:start_time).max,
+        [self, other].map(&:end_time).min
+      )
     end
 
     def /(other)
       [
         self.class.new(start_time, other.start_time),
         self.class.new(other.end_time, end_time)
-      ].reject(&:empty?).map { |potential| self & potential }
+      ].reject(&:disjoint?).map { |potential| self & potential }
     end
 
     private

--- a/lib/biz/timeline/backward.rb
+++ b/lib/biz/timeline/backward.rb
@@ -10,8 +10,12 @@ module Biz
 
       private
 
-      def occurred?(period, time)
-        period.start_time <= time
+      def occurred?(period, terminus)
+        period.end_time <= terminus
+      end
+
+      def overflow?(*)
+        false
       end
 
       def comparison_period(period, terminus)

--- a/lib/biz/timeline/forward.rb
+++ b/lib/biz/timeline/forward.rb
@@ -10,8 +10,12 @@ module Biz
 
       private
 
-      def occurred?(period, time)
-        period.end_time >= time
+      def occurred?(period, terminus)
+        period.start_time > terminus
+      end
+
+      def overflow?(period, remaining)
+        period.duration == remaining
       end
 
       def comparison_period(period, terminus)

--- a/spec/biz_spec.rb
+++ b/spec/biz_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Biz do
       it 'delegates to the top-level schedule' do
         expect(
           described_class.time(2, :hours).after(Time.utc(2006, 1, 1))
-        ).to eq Time.utc(2006, 1, 8, 12)
+        ).to eq Time.utc(2006, 1, 15, 11)
       end
     end
 

--- a/spec/calculation/for_duration_spec.rb
+++ b/spec/calculation/for_duration_spec.rb
@@ -139,10 +139,10 @@ RSpec.describe Biz::Calculation::ForDuration do
       end
 
       describe '#after' do
-        let(:time) { Time.utc(2006, 1, 4, 15, 30) }
+        let(:time) { Time.utc(2006, 1, 4, 14, 30) }
 
         it 'returns the forward time after the elapsed duration' do
-          expect(calculation.after(time)).to eq Time.utc(2006, 1, 4, 17)
+          expect(calculation.after(time)).to eq Time.utc(2006, 1, 4, 16)
         end
 
         context 'when the scalar is zero' do
@@ -181,10 +181,10 @@ RSpec.describe Biz::Calculation::ForDuration do
       end
 
       describe '#after' do
-        let(:time) { Time.utc(2006, 1, 4, 14) }
+        let(:time) { Time.utc(2006, 1, 4, 13) }
 
         it 'returns the forward time after the elapsed duration' do
-          expect(calculation.after(time)).to eq Time.utc(2006, 1, 4, 17)
+          expect(calculation.after(time)).to eq Time.utc(2006, 1, 4, 16)
         end
 
         context 'when the scalar is zero' do

--- a/spec/time_segment_spec.rb
+++ b/spec/time_segment_spec.rb
@@ -28,6 +28,14 @@ RSpec.describe Biz::TimeSegment do
         Biz::Duration.new(end_time - start_time)
       )
     end
+
+    context 'when the time segment is disjoint' do
+      let(:time_segment) { described_class.new(end_time, start_time) }
+
+      it 'returns a zero duration' do
+        expect(time_segment.duration).to eq Biz::Duration.new(0)
+      end
+    end
   end
 
   describe '#start_time' do
@@ -77,8 +85,34 @@ RSpec.describe Biz::TimeSegment do
     context 'when the start time is after the end time' do
       let(:time_segment) { described_class.new(end_time + 1, end_time) }
 
+      it 'returns false' do
+        expect(time_segment.empty?).to eq false
+      end
+    end
+  end
+
+  describe '#disjoint?' do
+    context 'when the start time is before the end time' do
+      let(:time_segment) { described_class.new(start_time, start_time + 1) }
+
+      it 'returns false' do
+        expect(time_segment.disjoint?).to eq false
+      end
+    end
+
+    context 'when the start time is equal to the end time' do
+      let(:time_segment) { described_class.new(start_time, start_time) }
+
+      it 'returns false' do
+        expect(time_segment.disjoint?).to eq false
+      end
+    end
+
+    context 'when the start time is after the end time' do
+      let(:time_segment) { described_class.new(end_time + 1, end_time) }
+
       it 'returns true' do
-        expect(time_segment.empty?).to eq true
+        expect(time_segment.disjoint?).to eq true
       end
     end
   end
@@ -132,10 +166,8 @@ RSpec.describe Biz::TimeSegment do
       let(:other_start_time) { Time.utc(2006, 1, 1) }
       let(:other_end_time)   { Time.utc(2006, 1, 2) }
 
-      it 'returns a zero-duration time segment' do
-        expect(time_segment & other).to eq(
-          described_class.new(start_time, start_time)
-        )
+      it 'returns a disjoint time segment' do
+        expect(time_segment & other).to be_disjoint
       end
     end
 
@@ -191,10 +223,8 @@ RSpec.describe Biz::TimeSegment do
       let(:other_start_time) { Time.utc(2006, 2, 1) }
       let(:other_end_time)   { Time.utc(2006, 2, 7) }
 
-      it 'returns a zero-duration time segment' do
-        expect(time_segment & other).to eq(
-          described_class.new(other_start_time, other_start_time)
-        )
+      it 'returns a disjoint time segment' do
+        expect(time_segment & other).to be_disjoint
       end
     end
   end

--- a/spec/timeline/backward_spec.rb
+++ b/spec/timeline/backward_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Biz::Timeline::Backward do
       end
     end
 
-    context 'when the terminus at the end of the first period' do
+    context 'when the terminus is at the end of the first period' do
       let(:terminus) { Time.utc(2006, 2) }
 
       it 'returns no periods' do
@@ -106,8 +106,10 @@ RSpec.describe Biz::Timeline::Backward do
     context 'when the duration is zero' do
       let(:duration) { Biz::Duration.new(0) }
 
-      it 'returns no periods' do
-        expect(timeline.for(duration).to_a).to eq []
+      it 'returns the first active moment backward in time' do
+        expect(timeline.for(duration).to_a).to eq [
+          Biz::TimeSegment.new(Time.utc(2006, 2), Time.utc(2006, 2))
+        ]
       end
     end
 

--- a/spec/timeline/forward_spec.rb
+++ b/spec/timeline/forward_spec.rb
@@ -45,7 +45,8 @@ RSpec.describe Biz::Timeline::Forward do
       it 'returns the proper periods' do
         expect(timeline.until(terminus).to_a).to eq [
           Biz::TimeSegment.new(Time.utc(2006), Time.utc(2006, 2)),
-          Biz::TimeSegment.new(Time.utc(2007), Time.utc(2007, 2))
+          Biz::TimeSegment.new(Time.utc(2007), Time.utc(2007, 2)),
+          Biz::TimeSegment.new(Time.utc(2008), Time.utc(2008))
         ]
       end
     end
@@ -53,8 +54,10 @@ RSpec.describe Biz::Timeline::Forward do
     context 'when the terminus at the beginning of the first period' do
       let(:terminus) { Time.utc(2006) }
 
-      it 'returns no periods' do
-        expect(timeline.until(terminus).to_a).to eq []
+      it 'returns the first active moment forward in time' do
+        expect(timeline.until(terminus).to_a).to eq [
+          Biz::TimeSegment.new(Time.utc(2006), Time.utc(2006))
+        ]
       end
     end
 
@@ -103,8 +106,10 @@ RSpec.describe Biz::Timeline::Forward do
     context 'when the duration is zero' do
       let(:duration) { Biz::Duration.new(0) }
 
-      it 'returns no periods' do
-        expect(timeline.for(duration).to_a).to eq []
+      it 'returns the first active moment forward in time' do
+        expect(timeline.for(duration).to_a).to eq [
+          Biz::TimeSegment.new(Time.utc(2006), Time.utc(2006))
+        ]
       end
     end
 
@@ -121,9 +126,10 @@ RSpec.describe Biz::Timeline::Forward do
     context 'when the duration is the length of the first period' do
       let(:duration) { Biz::Duration.seconds(in_seconds(days: 31)) }
 
-      it 'returns the first period' do
+      it 'returns the proper periods' do
         expect(timeline.for(duration).to_a).to eq [
-          Biz::TimeSegment.new(Time.utc(2006), Time.utc(2006, 2))
+          Biz::TimeSegment.new(Time.utc(2006), Time.utc(2006, 2)),
+          Biz::TimeSegment.new(Time.utc(2007), Time.utc(2007))
         ]
       end
     end
@@ -134,7 +140,8 @@ RSpec.describe Biz::Timeline::Forward do
       it 'returns the proper periods' do
         expect(timeline.for(duration).to_a).to eq [
           Biz::TimeSegment.new(Time.utc(2006), Time.utc(2006, 2)),
-          Biz::TimeSegment.new(Time.utc(2007), Time.utc(2007, 2))
+          Biz::TimeSegment.new(Time.utc(2007), Time.utc(2007, 2)),
+          Biz::TimeSegment.new(Time.utc(2008), Time.utc(2008))
         ]
       end
     end


### PR DESCRIPTION
Before, a lack of handling of time segment endpoints in calculations consistent with how they are handled elsewhere in the gem (that is, *including* the start time and *excluding* the end time) was causing weird behavior and inconsistencies across both `#for` and `#until`
period generation methods, which filtered down to high-level calculations.

When looking forward in time, if it consumes, or lands at the end of, a period one extra "moment" period should be generated to compensate for the fact that the end time of a time segment is not considered part of that segment. Under similar circumstances when looking backward in time, since the start time of a time segment is considered inclusive to that time segment, calculations that end on or at that moment should not proceed to generate the next moment period.

A nice side effect of making this behavior consistent at the lowest level of the engine is that we can remove special-case handling that was added to the high-level calculation object in support of zero-scalar calculations. We can simply use the period and timeline objects normally and get the correct behavior. Woohoo!

Running the benchmark suite, we don't see a meaningful delta in performance characteristics with these changes.


#### Before:
```
Biz.configure do |config|
  config.hours = {
    mon: {'00:00' => '24:00'},
    tue: {'00:00' => '24:00'},
    wed: {'00:00' => '24:00'},
    thu: {'00:00' => '24:00'},
    fri: {'00:00' => '24:00'}
  }
end

monday = Time.utc(2019, 1, 14)

Biz.time(1, :days).before(monday)     #=> 2019-01-11 00:00:00 UTC
Biz.time(2, :days).before(monday)     #=> 2019-01-10 00:00:00 UTC
Biz.time(4, :days).before(monday)     #=> 2019-01-08 00:00:00 UTC
Biz.time(5, :days).before(monday)     #=> 2019-01-05 00:00:00 UTC <- Expected 1/7/19
Biz.time(0, :days).before(monday)     #=> 2019-01-12 00:00:00 UTC <- Expected 1/14/19
Biz.time(0, :days).before(monday + 1) #=> 2019-01-14 00:00:01 UTC <- Correct

tuesday = Time.utc(2019, 1, 15)

Biz.time(0, :days).before(tuesday)    #=> 2019-01-15 00:00:00 UTC
Biz.time(1, :days).before(tuesday)    #=> 2019-01-12 00:00:00 UTC <- Expected 1/14/19
Biz.time(1, :day).before(tuesday + 1) #=> 2019-01-14 00:00:01 UTC <- Correct
Biz.time(5, :days).before(tuesday)    #=> 2019-01-08 00:00:00 UTC

friday = Time.utc(2019, 1, 11)
Biz.time(24, :hours).after(friday) #=> 2019-01-12 00:00:00 UTC <- 1/14/19 expected
Biz.time(1, :day).after(friday)    #=> 2019-01-14 00:00:00 UTC <- Correct
```

#### After:
```
Biz.configure do |config|
  config.hours = {
    mon: {'00:00' => '24:00'},
    tue: {'00:00' => '24:00'},
    wed: {'00:00' => '24:00'},
    thu: {'00:00' => '24:00'},
    fri: {'00:00' => '24:00'}
  }
end

monday = Time.utc(2019, 1, 14)

Biz.time(1, :days).before(monday)     #=> 2019-01-11 00:00:00 UTC
Biz.time(2, :days).before(monday)     #=> 2019-01-10 00:00:00 UTC
Biz.time(4, :days).before(monday)     #=> 2019-01-08 00:00:00 UTC
Biz.time(5, :days).before(monday)     #=> 2019-01-07 00:00:00 UTC
Biz.time(0, :days).before(monday)     #=> 2019-01-14 00:00:00 UTC
Biz.time(0, :days).before(monday + 1) #=> 2019-01-14 00:00:01 UTC

tuesday = Time.utc(2019, 1, 15)

Biz.time(0, :days).before(tuesday)    #=> 2019-01-15 00:00:00 UTC
Biz.time(1, :days).before(tuesday)    #=> 2019-01-14 00:00:00 UTC
Biz.time(1, :day).before(tuesday + 1) #=> 2019-01-14 00:00:01 UTC
Biz.time(5, :days).before(tuesday)    #=> 2019-01-08 00:00:00 UTC

friday = Time.utc(2019, 1, 11)

Biz.time(24, :hours).after(friday) #=> 2019-01-14 00:00:00 UTC
Biz.time(1, :day).after(friday)    #=> 2019-01-14 00:00:00 UTC
```

Fixes #138.