### PR TITLE
Handle hours like "9:00" with no leading 0

### DIFF
--- a/lib/biz/day_time.rb
+++ b/lib/biz/day_time.rb
@@ -8,7 +8,7 @@ module Biz
     module Timestamp
       FORMAT  = '%02d:%02d'
       PATTERN =
-        /\A(?<hour>\d{2}):(?<minute>\d{2})(:?(?<second>\d{2}))?\Z/.freeze
+        /\A(?<hour>\d{1,2}):(?<minute>\d{2})(:?(?<second>\d{2}))?\Z/.freeze
     end
 
     include Comparable

--- a/spec/day_time_spec.rb
+++ b/spec/day_time_spec.rb
@@ -106,6 +106,16 @@ RSpec.describe Biz::DayTime do
           )
         end
       end
+
+      context 'with short format hours' do
+        let(:timestamp) { '8:55:23' }
+
+        it 'returns the appropriate day time' do
+          expect(described_class.from_timestamp(timestamp)).to eq(
+            described_class.new(day_second(hour: 8, min: 55, sec: 23))
+          )
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Hours are sometimes written in short format, not being left padded.

In current implementation, this is not recognized:

```
> Biz::DayTime.from_timestamp('01:10:00')
=> #<Biz::DayTime:0x000055a7e6765820 @day_second=4200>

> Biz::DayTime.from_timestamp('1:10:00')
=> nil
```

This forces applications using biz to work around it, and can lead to
production bug if someone working in 24h format only uses afternoon
hours before deploying.

This commit implements support for short format.